### PR TITLE
Implemented DataverseApi.setMetadataBlocksRoot

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
@@ -1,0 +1,33 @@
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.model.DataMessage;
+import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DataverseSetMetadataBlocksRoot extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DataverseSetMetadataBlocksRoot.class);
+
+    private static void setMetadataBlocksRoot(String alias, boolean isRoot) throws IOException, DataverseException {
+        log.info("Setting metadata blocks isRoot to: {} for dataverse with alias: {}", isRoot, alias);
+        DataverseHttpResponse<DataMessage> r = client.dataverse(alias).setMetadataBlocksRoot(false);
+        log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
+        log.info("Message: {}", r.getData().getMessage());
+    }
+
+    public static void main(String[] args) throws Exception {
+        // There should always be a 'root' verse
+        String verseAlias = "root";
+        // We can set this to false, which is a bit odd, it is a root, but not for blocks inheritance behaviour
+        setMetadataBlocksRoot(verseAlias, false);
+        // And then to true
+        setMetadataBlocksRoot(verseAlias, true);
+    }
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseException;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -262,8 +263,8 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DataMessage> setMetadataBlocksRoot(boolean isRoot) throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
+        return httpClientWrapper.putTextString(subPath.resolve("metadatablocks/isRoot"), Boolean.toString(isRoot), 
+                Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap(), DataMessage.class);
     }
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -106,6 +106,10 @@ class HttpClientWrapper implements MediaTypes {
         return wrap(putString(subPath, s, APPLICATION_JSON_LD, parameters, headers), c);
     }
 
+    public <D> DataverseHttpResponse<D> putTextString(Path subPath, String s, Map<String, String> parameters, Map<String, String> headers, Class<?>... c) throws IOException, DataverseException {
+        return wrap(putString(subPath, s, TEXT_PLAIN, parameters, headers), c);
+    }
+    
     private HttpResponse putString(Path subPath, String s, String mediaType, Map<String, String> parameters, Map<String, String> headers) throws IOException, DataverseException {
         HttpPut put = new HttpPut(buildURi(subPath, parameters));
         put.setHeader(HttpHeaders.CONTENT_TYPE, mediaType);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/MediaTypes.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/MediaTypes.java
@@ -19,4 +19,5 @@ public interface MediaTypes {
 
     String APPLICATION_JSON = "application/json";
     String APPLICATION_JSON_LD = "application/json-ld";
+    String TEXT_PLAIN = "text/plain";
 }


### PR DESCRIPTION
Fixes DD-679

# Description of changes
Implemented DataverseApi.setMetadataBlocksRoot

# How to test
Run nl.knaw.dans.lib.dataverse.example.DataverseSetMetadataBlocksRoot#main

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
