### PR TITLE
DD-677: 3rd try -  fix path problems for DatasetGetVersion

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -28,7 +28,8 @@ abstract class AbstractApi {
     protected Path buildPath(Path base, String... components) {
         Path p = base;
         for (String c: components) {
-            p  = p.resolve(c + "/");
+            if (c!= null && !c.equals("") && !c.equals(":latest"))
+                p  = p.resolve(c + "/");
         }
         return p;
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -28,7 +28,7 @@ abstract class AbstractApi {
     protected Path buildPath(Path base, String... components) {
         Path p = base;
         for (String c: components) {
-            if (c!= null && !c.equals("") && !c.equals(":latest"))
+            if (!"".equals(c) && !":latest".equals(c))
                 p  = p.resolve(c + "/");
         }
         return p;


### PR DESCRIPTION
Fixes DD-677: 3rd try -  fix path problems for DatasetGetVersion

# Description of changes
Ignore empty components and ":latest" in `buildPath`.
Alternatively, you might want to revert 0fa9c798afe5faa16120830a114f0783b9bb9f43 or another solution.

# How to test
* start `dev_archaeology-2021-10-30.box`
* run DatasetGetFiles and with command line arguments: `doi:10.5072/DAR/HKGQKI 1`
* DasetGetVersion should also work.

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
