### PR TITLE
Fixed DatasetApi.getVersion

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
@@ -28,9 +28,11 @@ public class DatasetGetVersion extends ExampleBase {
     private static final Logger log = LoggerFactory.getLogger(DatasetGetVersion.class);
 
     public static void main(String[] args) throws Exception {
-        DataverseResponse<List<DatasetVersion>> r = client.dataset(args[0]).getVersion(":latest");
+        String persistentId = args[0];
+        String version = args[1];
+        DataverseResponse<DatasetVersion> r = client.dataset(persistentId).getVersion(version);
         log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
-        log.info("Create Time: {}", r.getData().get(0).getCreateTime());
-        log.info("Version State: {}", r.getData().get(0).getVersionState());
+        log.info("Create Time: {}", r.getData().getCreateTime());
+        log.info("Version State: {}", r.getData().getVersionState());
     }
 }

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -27,8 +27,9 @@ abstract class AbstractApi {
 
     protected Path buildPath(Path base, String... components) {
         Path p = base;
-        for (String c: components) {
-            p  = p.resolve(c + "/");
+        for (String c : components) {
+            if (!"".equals(c))
+                p = p.resolve(c + "/");
         }
         return p;
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.nio.file.Path;
 
 abstract class AbstractApi {
@@ -28,7 +30,7 @@ abstract class AbstractApi {
     protected Path buildPath(Path base, String... components) {
         Path p = base;
         for (String c : components) {
-            if (!"".equals(c))
+            if (StringUtils.isNotBlank(c))
                 p = p.resolve(c + "/");
         }
         return p;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.lib.dataverse;
 
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +52,9 @@ public class DatasetApi extends AbstractApi {
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset
      *
      */
-    public DataverseResponse<List<DatasetVersion>> getVersion(String version) throws IOException, DataverseException {
-        return getVersionedFromTarget("", version, List.class, DatasetVersion.class);
+    public DataverseResponse<DatasetVersion> getVersion(String version) throws IOException, DataverseException {
+        if (StringUtils.isBlank(version)) throw new IllegalArgumentException("Argument 'version' may not be empty");
+        return getVersionedFromTarget("", version, DatasetVersion.class);
     }
 
     /**


### PR DESCRIPTION
Fixes NO JIRA

# Description of changes
* The return type of the `getVersion` API was wrong. Instead of a list of versions it should just return a single version.
* An empty version should not be accepted.

# How to test
Run the example:
* Provide a version, or labels such as `:latest`, `:latest-published` and `:draft`.
* Provide `""` as version to test that it gives an `IllegalArgumentException`.

# Related PRs 
https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/6

# Notify
@DANS-KNAW/dataversedans
