### PR TITLE
DD-680: dans-dataverse-client-lib: implement DataverseApi.publish()

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
@@ -17,11 +17,10 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
-import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetPublicationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 
 public class DatasetPublish extends ExampleBase {
 
@@ -30,8 +29,9 @@ public class DatasetPublish extends ExampleBase {
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
         log.info("--- BEGIN JSON OBJECT ---");
-        DataverseResponse<List<FileMeta>> r = client.dataset(persistentId).publish();
+        DataverseResponse<DatasetPublicationResult> r = client.dataset(persistentId).publish();
         log.info("--- END JSON OBJECT ---");
         log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
+        log.info("Persistent Url: {}", r.getData().getPersistentUrl());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DatasetPublish extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetPublish.class);
+
+    public static void main(String[] args) throws Exception {
+        String persistentId = args[0];
+        log.info("--- BEGIN JSON OBJECT ---");
+        DataverseResponse<List<FileMeta>> r = client.dataset(persistentId).publish();
+        log.info("--- END JSON OBJECT ---");
+        log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
+    }
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
@@ -44,7 +44,5 @@ public class DataverseCreate extends ExampleBase {
         DataverseHttpResponse<Dataverse> r = client.dataverse("root").create(dataverse);
         log.info("--- END JSON OBJECT ---");
         log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
-        log.info("Created: {}", r.getData().getDescription());
-        log.info("Creation Date: {}", r.getData().getCreationDate());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
@@ -44,5 +44,7 @@ public class DataverseCreate extends ExampleBase {
         DataverseHttpResponse<Dataverse> r = client.dataverse("root").create(dataverse);
         log.info("--- END JSON OBJECT ---");
         log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
+        log.info("Created: {}", r.getData().getDescription());
+        log.info("Creation Date: {}", r.getData().getCreationDate());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
@@ -27,7 +28,9 @@ public class DataversePublish extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         log.info("--- CREATE FIRST A test DATAVERSE IF IT DOESN'T ALREADY EXIST ---");
-        DataverseCreate.main(new String[]{""});
+        try {
+            DataverseCreate.main(new String[]{""});
+        } catch (DataverseException e) {}
         log.info("====================================");
 
         log.info("--- PUBLISH test DATAVERSE ---");

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
@@ -27,13 +27,7 @@ public class DataversePublish extends ExampleBase {
     private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
 
     public static void main(String[] args) throws Exception {
-        log.info("--- CREATE FIRST A test DATAVERSE IF IT DOESN'T ALREADY EXIST ---");
-        try {
-            DataverseCreate.main(new String[]{""});
-        } catch (DataverseException e) {}
-        log.info("====================================");
-
-        log.info("--- PUBLISH test DATAVERSE ---");
+        // Notice: the test dataverse instance has to exist before calling this method
         log.info("--- BEGIN JSON OBJECT ---");
         DataverseHttpResponse<DataMessage> r = client.dataverse("test").publish();
         log.info("--- END JSON OBJECT ---");

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.DataMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataversePublish extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
+
+    public static void main(String[] args) throws Exception {
+        log.info("--- CREATE FIRST A test DATAVERSE IF IT DOESN'T ALREADY EXIST ---");
+        DataverseCreate.main(new String[]{""});
+        log.info("====================================");
+
+        log.info("--- PUBLISH test DATAVERSE ---");
+        log.info("--- BEGIN JSON OBJECT ---");
+        DataverseHttpResponse<DataMessage> r = client.dataverse("test").publish();
+        log.info("--- END JSON OBJECT ---");
+        log.info("Status Line of DATAVERSE PUBLICATION: {}", r.getHttpResponse().getStatusLine());
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -82,9 +82,9 @@ public class DatasetApi extends AbstractApi {
     /**
      * See [Dataverse API Guide].
      *
-     * [Dataverse API Guide]:https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset
+     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset
      */
-    public DataverseResponse<List<FileMeta>> publish() throws IOException, DataverseException {
+    public DataverseResponse<DatasetPublicationResult> publish() throws IOException, DataverseException {
         Path path = buildPath(targetBase, persistendId, publish);
         HashMap<String, List<String>> parameters = new HashMap<>();
         parameters.put("persistentId", Collections.singletonList(id));

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetPublicationResult;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ public class DatasetApi extends AbstractApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
     private static final String persistendId = ":persistentId/";
+    private static final String publish = "actions/:publish";
 
     private final Path targetBase;
     private final String id;
@@ -77,6 +79,19 @@ public class DatasetApi extends AbstractApi {
         return getVersionedFromTarget("files", version, List.class, FileMeta.class);
     }
 
+    /**
+     * See [Dataverse API Guide].
+     *
+     * [Dataverse API Guide]:https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset
+     */
+    public DataverseResponse<List<FileMeta>> publish() throws IOException, DataverseException {
+        Path path = buildPath(targetBase, persistendId, publish);
+        HashMap<String, List<String>> parameters = new HashMap<>();
+        parameters.put("persistentId", Collections.singletonList(id));
+        parameters.put("type", Collections.singletonList("major"));
+        return httpClientWrapper.postJsonString(path, "", parameters, new HashMap<>(), DatasetPublicationResult.class);
+    }
+
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#export-metadata-of-a-dataset-in-various-formats
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#schema-org-json-ld
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#view-dataset-files-and-folders-as-a-directory-index
@@ -85,7 +100,6 @@ public class DatasetApi extends AbstractApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-metadata
-    // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#set-citation-date-field-type-for-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#revert-citation-date-field-type-to-default-for-dataset

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -42,6 +42,7 @@ public class DataverseApi extends AbstractApi {
 
     private static final Logger log = LoggerFactory.getLogger(DataverseApi.class);
     private final Path subPath;
+    private static final String publish = "actions/:publish";
 
     protected DataverseApi(HttpClientWrapper httpClientWrapper, String alias) {
         super(httpClientWrapper);
@@ -315,8 +316,7 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DataMessage> publish() throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
+        return httpClientWrapper.postJsonString(subPath.resolve(publish), "", new HashMap<>(), new HashMap<>(), Dataverse.class);
     }
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -316,7 +316,7 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DataMessage> publish() throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.postJsonString(subPath.resolve(publish), "", new HashMap<>(), new HashMap<>(), Dataverse.class);
+        return httpClientWrapper.postJsonString(subPath.resolve(publish), "", new HashMap<>(), new HashMap<>(), DataMessage.class);
     }
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetPublicationResult.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetPublicationResult.java
@@ -26,6 +26,7 @@ public class DatasetPublicationResult {
     private String publisher;
     private String publicationDate;
     private String storageIdentifier;
+    private String metadataLanguage;
 
     public int getId() {
         return id;
@@ -89,5 +90,13 @@ public class DatasetPublicationResult {
 
     public void setStorageIdentifier(String storageIdentifier) {
         this.storageIdentifier = storageIdentifier;
+    }
+
+    public String getMetadataLanguage() {
+        return metadataLanguage;
+    }
+
+    public void setMetadataLanguage(String metadataLanguage) {
+        this.metadataLanguage = metadataLanguage;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
@@ -31,6 +31,8 @@ public class DatasetVersion {
     private String lastUpdateTime; // TODO: timestamp?
     private String releaseTime; // TODO: timestamp?
     private String createTime; // TODO: timestamp?
+    private String distributionDate; // TODO: timestamp?
+    private String productionDate; // TODO: timestamp?
     private boolean fileAccessRequest;
     private String termsOfUse;
     private String termsOfAccess;
@@ -127,6 +129,22 @@ public class DatasetVersion {
 
     public void setCreateTime(String createTime) {
         this.createTime = createTime;
+    }
+
+    public String getDistributionDate() {
+        return distributionDate;
+    }
+
+    public void setDistributionDate(String distributionDate) {
+        this.distributionDate = distributionDate;
+    }
+
+    public String getProductionDate() {
+        return productionDate;
+    }
+
+    public void setProductionDate(String productionDate) {
+        this.productionDate = productionDate;
     }
 
     public boolean isFileAccessRequest() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
@@ -22,6 +22,8 @@ public class DataFile {
   private String filename;
   private String contentType;
   private long filesize;
+  private String description;
+  private Embargo embargo;
   private String storageIdentifier;
   private int rootDataFileId;
   private Checksum checksum;
@@ -41,6 +43,14 @@ public class DataFile {
 
   public void setChecksum(Checksum checksum) {
     this.checksum = checksum;
+  }
+
+  public Embargo getEmbargo() {
+    return embargo;
+  }
+
+  public void setEmbargo(Embargo embargo) {
+    this.embargo = embargo;
   }
 
   public int getRootDataFileId() {
@@ -65,6 +75,14 @@ public class DataFile {
 
   public void setFilesize(long filesize) {
     this.filesize = filesize;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
   }
 
   public String getContentType() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Embargo.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Embargo.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.file;
+
+public class Embargo {
+
+  private String dateAvailable;
+  private String reason;
+
+  public String getDateAvailable() {
+    return dateAvailable;
+  }
+
+  public void setDateAvailable(String dateAvailable) {
+    this.dateAvailable = dateAvailable;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+}


### PR DESCRIPTION
Fixes DD-680

# Description of changes
* added method `DataverseApi.publish()`
* as bonus:) also added method `Dataset.publish()`
* while testing I noticed that in some model files there were missing some fields; added also those

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
