### PR TITLE
DD-705: dans-dataverse-client-lib: implement awaitLock / awaitUnlock

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
@@ -30,8 +30,8 @@ public class DatasetAwaitLock extends ExampleBase {
     // this program should always return a message about RuntimeException.
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
-        int awaitLockStateMaxNumberOfRetries = Integer.valueOf(args[1]);
-        int awaitLockStateMillisecondsBetweenRetries = Integer.valueOf(args[2]);
+        int awaitLockStateMaxNumberOfRetries = Integer.parseInt(args[1]);
+        int awaitLockStateMillisecondsBetweenRetries = Integer.parseInt(args[2]);
         try {
             client.dataset(persistentId).awaitLock("test", awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
             log.info("awaitUnLock method executed successfully");

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DatasetAwaitLock extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetAwaitLock.class);
+
+    // Notice: Because there are no locks active in this test situation,
+    // this program should always return a message about RuntimeException.
+    public static void main(String[] args) throws Exception {
+        String persistentId = args[0];
+        int awaitLockStateMaxNumberOfRetries = Integer.valueOf(args[1]);
+        int awaitLockStateMillisecondsBetweenRetries = Integer.valueOf(args[2]);
+        try {
+            client.dataset(persistentId).awaitLock("test", awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+            log.info("awaitUnLock method executed successfully");
+        } catch (RuntimeException e) {
+            log.error(String.format("awaitLock method threw a RuntimeException: %s", e.getMessage()));
+        }
+        catch (IOException | DataverseException | InterruptedException e) {
+            log.error(String.format("awaitLock method threw an Exception: %s", e.getMessage()));
+        }
+    }
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
@@ -15,12 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
-import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 
 public class DatasetAwaitUnlock extends ExampleBase {
 
@@ -32,14 +30,7 @@ public class DatasetAwaitUnlock extends ExampleBase {
         String persistentId = args[0];
         int awaitLockStateMaxNumberOfRetries = Integer.valueOf(args[1]);
         int awaitLockStateMillisecondsBetweenRetries = Integer.valueOf(args[2]);
-        try {
-            client.dataset(persistentId).awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
-            log.info("awaitUnLock method executed successfully");
-        } catch (RuntimeException e) {
-            log.error(String.format("awaitUnLock method threw a RuntimeException: %s", e.getMessage()));
-        }
-        catch (IOException | DataverseException | InterruptedException e) {
-            log.error(String.format("awaitUnLock method threw an Exception: %s", e.getMessage()));
-        }
+        client.dataset(persistentId).awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+        log.info("awaitUnLock method executed successfully");
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DatasetAwaitUnlock extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetAwaitUnlock.class);
+
+    // Notice: Because there are no locks active in this test situation,
+    // this program should always return a message about successful execution.
+    public static void main(String[] args) throws Exception {
+        String persistentId = args[0];
+        int awaitLockStateMaxNumberOfRetries = Integer.valueOf(args[1]);
+        int awaitLockStateMillisecondsBetweenRetries = Integer.valueOf(args[2]);
+        try {
+            client.dataset(persistentId).awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+            log.info("awaitUnLock method executed successfully");
+        } catch (RuntimeException e) {
+            log.error(String.format("awaitUnLock method threw a RuntimeException: %s", e.getMessage()));
+        }
+        catch (IOException | DataverseException | InterruptedException e) {
+            log.error(String.format("awaitUnLock method threw an Exception: %s", e.getMessage()));
+        }
+    }
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
@@ -28,8 +28,8 @@ public class DatasetAwaitUnlock extends ExampleBase {
     // this program should always return a message about successful execution.
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
-        int awaitLockStateMaxNumberOfRetries = Integer.valueOf(args[1]);
-        int awaitLockStateMillisecondsBetweenRetries = Integer.valueOf(args[2]);
+        int awaitLockStateMaxNumberOfRetries = Integer.parseInt(args[1]);
+        int awaitLockStateMillisecondsBetweenRetries = Integer.parseInt(args[2]);
         client.dataset(persistentId).awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
         log.info("awaitUnLock method executed successfully");
     }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.workflow.Lock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DatasetGetLocks extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetGetLocks.class);
+
+    public static void main(String[] args) throws Exception {
+        /*
+         * Start the example and then do something with the dataset that causes a lock, such as ingesting a
+         * tabular file.
+         */
+
+        String persistentId = args[0];
+        int awaitLockStateMaxNumberOfRetries = Integer.parseInt(args[1]);
+        int awaitLockStateMillisecondsBetweenRetries = Integer.parseInt(args[2]);
+        client.dataset(persistentId).awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+
+        for (int i = 0; i < 300; i += 1) {
+            DataverseResponse<List<Lock>> response = client.dataset(persistentId).getLocks();
+            List<Lock> locks = response.getData();
+            log.trace(String.format("Locks: %s", locks));
+            if (!locks.isEmpty())
+                log.info(String.format("Dataset is currently locked by: %s", locks));
+            Thread.sleep(50);
+        }
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.lib.dataverse;
 
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import nl.knaw.dans.lib.dataverse.model.workflow.Lock;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,8 @@ public class DatasetApi extends AbstractApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
     private static final String persistendId = ":persistentId/";
+    private static final int awaitLockStateMaxNumberOfRetries = 30;
+    private static final int awaitLockStateMillisecondsBetweenRetries = 500;
 
     private final Path targetBase;
     private final String id;
@@ -125,5 +128,125 @@ public class DatasetApi extends AbstractApi {
         else {
             return httpClientWrapper.get(buildPath(targetBase, id, "versions", version, endPoint), outputClass);
         }
+    }
+
+    private <D> DataverseHttpResponse<D> getUnversionedFromTarget(String endPoint, Class<?>... outputClass) throws IOException, DataverseException {
+        log.trace("ENTER");
+        if (isPersistentId) {
+            HashMap<String, List<String>> parameters = new HashMap<>();
+            parameters.put("persistentId", Collections.singletonList(id));
+            return httpClientWrapper.get(buildPath(targetBase, persistendId, endPoint), parameters, outputClass);
+        }
+        else {
+            return httpClientWrapper.get(buildPath(targetBase, id, endPoint), outputClass);
+        }
+    }
+
+    /**
+     * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks]]
+     * @return
+     */
+    public DataverseResponse<List<Lock>> getLocks() throws IOException, DataverseException {
+        log.trace("getting locks from Dataverse");
+        return getUnversionedFromTarget("locks", List.class);
+    }
+
+
+    /**
+     * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions
+     * in this library, this does not correspond directly with an API call. Rather the [[getLocks]] call is done repeatedly
+     * to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset
+     * it is not guaranteed that the locks, once cleared, stay that way.
+     *
+     * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
+     * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
+     * @return
+     */
+    public void awaitUnlock(int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException, InterruptedException {
+        log.trace(String.format("awaitUnlock: maxNumberOfRetries %d, waitTimeInMilliseconds %d", maxNumberOfRetries, waitTimeInMilliseconds));
+        awaitLockState(this::notLocked, "", "Wait for unlock expired", maxNumberOfRetries, waitTimeInMilliseconds);
+    }
+
+    public void awaitUnlock() throws IOException, DataverseException, InterruptedException {
+        awaitUnlock(awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+    }
+
+    /**
+     * Utility function that lets you wait until a specified lock type is set. Unlike most other functions
+     * in this library, this does not correspond directly with an API call. Rather the [[getLocks]] call is done repeatedly
+     * to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been
+     * locked on its behalf, so that it can be sure to have exclusive access via its invocation ID.
+     *
+     * @param lockType               the lock type to wait for
+     * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
+     * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
+     * @return
+     */
+    public void awaitLock(String lockType, int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException, InterruptedException {
+        log.trace(String.format("awaitLock: lockType %s, maxNumberOfRetries %d, waitTimeInMilliseconds %d", lockType, maxNumberOfRetries, waitTimeInMilliseconds));
+        awaitLockState(this::isLocked, lockType, String.format("Wait for lock of type %s expired", lockType), maxNumberOfRetries, waitTimeInMilliseconds);
+    }
+
+    public void awaitLock(String lockType) throws IOException, DataverseException, InterruptedException {
+        awaitLock(lockType, awaitLockStateMaxNumberOfRetries, awaitLockStateMillisecondsBetweenRetries);
+    }
+
+    /**
+     * Private functional interface to get the locking status, and methods implementing it.
+     */
+    @FunctionalInterface
+    private interface Locked {
+        Boolean get(List<Lock> locks, String lockType);
+    }
+
+    private Boolean isLocked(List<Lock> locks, String lockType) {
+        for (Lock lock : locks) {
+            if (lock.getLockType() == lockType)
+                return true;
+        }
+        return false;
+    }
+
+    private Boolean notLocked(List<Lock> locks, String lockType) {
+        return locks.isEmpty();
+    }
+
+
+    /**
+     * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs
+     * within `maxNumberOrRetries` with `waitTimeInMilliseconds` pauses.
+     *
+     * @param lockState              the function that returns whether the required state has been reached
+     * @param lockType               type of locking
+     * @param errorMessage           error to report in LockException if it occurs
+     * @param maxNumberOfRetries     the maximum number of tries
+     * @param waitTimeInMilliseconds the time to wait between tries
+     * @return
+     */
+    private void awaitLockState(Locked lockState, String lockType, String errorMessage, int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException, InterruptedException {
+        int numberOfTimesTried = 0;
+
+        class CurrentLocks {
+            private List<Lock> getCurrentLocks() throws IOException, DataverseException {
+                List<Lock> locks = getLocks().getData();
+                log.debug(String.format("Current locks: %s", locks.toString()));
+                return locks;
+            }
+
+            private Boolean slept() throws InterruptedException {
+                log.debug(String.format("Sleeping %d ms before next try..", waitTimeInMilliseconds));
+                Thread.sleep(waitTimeInMilliseconds);
+                return true;
+            }
+        }
+
+        CurrentLocks currentLocks = new CurrentLocks();
+        List<Lock> locks;
+        do {
+            locks = currentLocks.getCurrentLocks();
+            numberOfTimesTried += 1;
+        } while (!lockState.get(locks, lockType) && numberOfTimesTried != maxNumberOfRetries && currentLocks.slept());
+
+        if (!lockState.get(locks, lockType)) throw new RuntimeException(String.format("%s. Number of tries = %d, wait time between tries = %d ms.", errorMessage, maxNumberOfRetries, waitTimeInMilliseconds));
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/workflow/Lock.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/workflow/Lock.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.workflow;
+
+public class Lock {
+    private String lockType;
+    private String date;
+    private String user;
+    private String message;
+
+    public String getLockType() {
+        return lockType;
+    }
+
+    public void setLockType(String lockType) {
+        this.lockType = lockType;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/LockTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/LockTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.workflow;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LockTest extends ModelWorkflowFixture {
+    private static final Class<Lock> classUnderTest = Lock.class;
+
+    @Test
+    public void canDeserialize() throws Exception {
+        Lock lock = mapper.readValue(getTestJsonFileFor(classUnderTest), classUnderTest);
+        assertEquals(classUnderTest, lock.getClass());
+        assertEquals("test", lock.getLockType());
+        assertEquals("2021-11-19", lock.getDate());
+        assertEquals("user001", lock.getUser());
+        assertEquals("just for fun...", lock.getMessage());
+    }
+
+    @Test
+    public void roundTrip() throws Exception {
+        Lock lock = roundTrip(getTestJsonFileFor(classUnderTest), classUnderTest);
+        assertEquals(classUnderTest, lock.getClass());
+    }
+
+}

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/LockTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/LockTest.java
@@ -37,5 +37,4 @@ class LockTest extends ModelWorkflowFixture {
         Lock lock = roundTrip(getTestJsonFileFor(classUnderTest), classUnderTest);
         assertEquals(classUnderTest, lock.getClass());
     }
-
 }

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/ModelWorkflowFixture.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/workflow/ModelWorkflowFixture.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.workflow;
+
+import nl.knaw.dans.lib.dataverse.MapperFixture;
+
+public class ModelWorkflowFixture extends MapperFixture {
+
+    protected ModelWorkflowFixture() {
+        super("model/workflow/");
+    }
+}

--- a/lib/src/test/resources/model/workflow/Lock.json
+++ b/lib/src/test/resources/model/workflow/Lock.json
@@ -1,0 +1,6 @@
+{
+  "lockType": "test",
+  "date": "2021-11-19",
+  "user": "user001",
+  "message": "just for fun..."
+}


### PR DESCRIPTION
Fixes DD-705

# Description of changes
Added `DatasetApi` methods `awaitLock` and `awaitUnLock`

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
