### PR TITLE
DD-728: fields missing during test run

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
@@ -25,6 +25,11 @@ public class DataFile {
   private String description;
   private Embargo embargo;
   private String storageIdentifier;
+  private String originalFileFormat;
+  private String originalFormatLabel;
+  private Long originalFileSize;
+  private String originalFileName;
+  private String UNF;
   private int rootDataFileId;
   private Checksum checksum;
   private String creationDate; // TODO why not a DateTime?
@@ -132,5 +137,45 @@ public class DataFile {
 
   public void setId(int id) {
     this.id = id;
+  }
+
+  public String getUNF() {
+    return UNF;
+  }
+
+  public void setUNF(String UNF) {
+    this.UNF = UNF;
+  }
+
+  public String getOriginalFileName() {
+    return originalFileName;
+  }
+
+  public void setOriginalFileName(String originalFileName) {
+    this.originalFileName = originalFileName;
+  }
+
+  public Long getOriginalFileSize() {
+    return originalFileSize;
+  }
+
+  public void setOriginalFileSize(Long originalFileSize) {
+    this.originalFileSize = originalFileSize;
+  }
+
+  public String getOriginalFormatLabel() {
+    return originalFormatLabel;
+  }
+
+  public void setOriginalFormatLabel(String originalFormatLabel) {
+    this.originalFormatLabel = originalFormatLabel;
+  }
+
+  public String getOriginalFileFormat() {
+    return originalFileFormat;
+  }
+
+  public void setOriginalFileFormat(String originalFileFormat) {
+    this.originalFileFormat = originalFileFormat;
   }
 }


### PR DESCRIPTION
Fixes DD-728: fields missing during test run

# Description of changes

Missing fields that emerged from https://github.com/DANS-KNAW/dd-verify-file-migration/pull/3#pullrequestreview-828990356

probably files automagically converted by dataverse

# How to test

build into https://github.com/DANS-KNAW/dd-verify-file-migration/pull/3 and run with 

    dataverse:
      baseUrl: 'https://test.archaeology.datastations.nl/'

It returned no errors

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
