### PR TITLE
NO JIRA. X-Dataverse-invocationID

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
+import nl.knaw.dans.lib.dataverse.model.dataset.ControlledSingleValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.SingleValueField;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class CompoundFieldBuilder {
+    private final String typeName;
+    private final boolean multiple;
+    private final List<Map<String, SingleValueField>> values = new LinkedList<>();
+    private Map<String, SingleValueField> currentValue = new HashMap<>();
+
+    public CompoundFieldBuilder(String typeName, boolean multiple) {
+        this.typeName = typeName;
+        this.multiple = multiple;
+    }
+
+    public CompoundFieldBuilder nextValue() {
+        if (!multiple)
+            throw new IllegalStateException("Not a multiple value field");
+        values.add(currentValue);
+        currentValue = new HashMap<>();
+        return this;
+    }
+
+    public CompoundFieldBuilder addSubfield(String name, String value) {
+        currentValue.put(name, new PrimitiveSingleValueField(name, value));
+        return this;
+    }
+
+    public CompoundFieldBuilder addControlledSubfield(String name, String value) {
+        currentValue.put(name, new ControlledSingleValueField(name, value));
+        return this;
+    }
+
+    public CompoundField build() {
+        values.add(currentValue);
+        return new CompoundField(typeName, multiple, values);
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
@@ -68,7 +68,19 @@ public class DataverseClient {
     }
 
     public DatasetApi dataset(String pid) {
-        return new DatasetApi(httpClientWrapper, pid, true);
+        return dataset(pid, null);
+    }
+
+    public DatasetApi dataset(String pid, String invocationId) {
+        return new DatasetApi(httpClientWrapper, pid, true, invocationId);
+    }
+
+    public DatasetApi dataset(int pid) {
+        return dataset(pid, null);
+    }
+
+    public DatasetApi dataset(int pid, String invocationId) {
+        return new DatasetApi(httpClientWrapper, Integer.toString(pid), false, invocationId);
     }
 
     public DataverseApi dataverse(String alias) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
@@ -60,7 +60,6 @@ public class MetadataFieldDeserializer extends StdDeserializer {
                 if (subField) throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
                 Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
                 return new PrimitiveMultiValueField(
-                    typeClass,
                     typeName,
                     StreamSupport.stream(jsonNodeIterable.spliterator(), false)
                         .map(JsonNode::asText).collect(Collectors.toList()));
@@ -77,14 +76,12 @@ public class MetadataFieldDeserializer extends StdDeserializer {
                 if (subField) throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
                 Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
                 return new ControlledMultiValueField(
-                    typeClass,
                     typeName,
                     StreamSupport.stream(jsonNodeIterable.spliterator(), false)
                         .map(JsonNode::asText).collect(Collectors.toList()));
             }
             else {
                 return new ControlledSingleValueField(
-                    typeClass,
                     typeName,
                     valueNode.asText());
             }
@@ -93,7 +90,6 @@ public class MetadataFieldDeserializer extends StdDeserializer {
             if (subField) throw new IllegalArgumentException("Compound fields cannot contain compound fields as subfields");
             Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
             return new CompoundField(
-                typeClass,
                 typeName,
                 multiple,
                 StreamSupport.stream(jsonNodeIterable.spliterator(), false)

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundField.java
@@ -25,8 +25,8 @@ public class CompoundField extends MetadataField {
     public CompoundField() {
     }
 
-    public CompoundField(String typeClass, String typeName, boolean multiple, List<Map<String, SingleValueField>> value) {
-        super(typeClass, typeName, multiple);
+    public CompoundField(String typeName, boolean multiple, List<Map<String, SingleValueField>> value) {
+        super("compound", typeName, multiple);
         this.value = value;
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
@@ -23,8 +23,8 @@ public class ControlledMultiValueField extends MetadataField {
     public ControlledMultiValueField() {
     }
 
-    public ControlledMultiValueField(String typeClass, String typeName, List<String> value) {
-        super(typeClass, typeName, true);
+    public ControlledMultiValueField(String typeName, List<String> value) {
+        super("controlledVocabulary", typeName, true);
         this.value = value;
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
@@ -22,8 +22,8 @@ public class ControlledSingleValueField extends MetadataField implements SingleV
     public ControlledSingleValueField() {
     }
 
-    public ControlledSingleValueField(String typeClass, String typeName, String value) {
-        super(typeClass, typeName, false);
+    public ControlledSingleValueField(String typeName, String value) {
+        super("controlledVocabulary", typeName, false);
         this.value = value;
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FieldList.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FieldList.java
@@ -29,7 +29,7 @@ public class FieldList {
         this.fields = fields;
     }
 
-    public void add(PrimitiveSingleValueField field) {
+    public void add(MetadataField field) {
         fields.add(field);
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
@@ -23,8 +23,8 @@ public class PrimitiveMultiValueField extends MetadataField {
     public PrimitiveMultiValueField() {
     }
 
-    public PrimitiveMultiValueField(String typeClass, String typeName, List<String> value) {
-        super(typeClass, typeName, true);
+    public PrimitiveMultiValueField(String typeName, List<String> value) {
+        super("primitive", typeName, true);
         this.value = value;
     }
 


### PR DESCRIPTION
NO JIRA.

# Description of changes
* Adds the `X-Dataverse-invocationID` header with the invocation ID as value, if present. This currently happens only on `putToTarget`. It should be added to any method that **edits** the dataset that could be invoked during a `PrePublishDataset` workflow. It is not necessary for `publish` for example, because that can never be a valid action during the `PrePublisheDataset` workflow.

# How to test
Use `editMetadata` in a `PrePublishDataset` workflow step.

# Related PRs 
Replaces #16 

# Notify
@DANS-KNAW/dataversedans
