### PR TITLE
NO JIRA. Add invocation ID to other methods of DatasetApi.

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -175,7 +175,9 @@ public class DatasetApi extends AbstractApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#list-all-metadata-blocks-for-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#list-single-metadata-block-for-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset
+
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-metadata
+
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#set-citation-date-field-type-for-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#revert-citation-date-field-type-to-default-for-dataset
@@ -210,10 +212,10 @@ public class DatasetApi extends AbstractApi {
         if (isPersistentId) {
             HashMap<String, List<String>> parameters = new HashMap<>();
             parameters.put("persistentId", Collections.singletonList(id));
-            return httpClientWrapper.get(buildPath(targetBase, persistendId, "versions", version, endPoint), parameters, outputClass);
+            return httpClientWrapper.get(buildPath(targetBase, persistendId, "versions", version, endPoint), parameters, extraHeaders, outputClass);
         }
         else {
-            return httpClientWrapper.get(buildPath(targetBase, id, "versions", version, endPoint), outputClass);
+            return httpClientWrapper.get(buildPath(targetBase, id, "versions", version, endPoint), Collections.emptyMap(), extraHeaders, outputClass);
         }
     }
 
@@ -223,10 +225,10 @@ public class DatasetApi extends AbstractApi {
             HashMap<String, List<String>> parameters = new HashMap<>();
             parameters.put("persistentId", Collections.singletonList(id));
             parameters.putAll(queryParams);
-            return httpClientWrapper.get(buildPath(targetBase, persistendId, endPoint), parameters, outputClass);
+            return httpClientWrapper.get(buildPath(targetBase, persistendId, endPoint), parameters, extraHeaders, outputClass);
         }
         else {
-            return httpClientWrapper.get(buildPath(targetBase, id, endPoint), outputClass);
+            return httpClientWrapper.get(buildPath(targetBase, id, endPoint), Collections.emptyMap(), extraHeaders, outputClass);
         }
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,12 @@ class HttpClientWrapper implements MediaTypes {
     }
 
     public <D> DataverseHttpResponse<D> get(Path subPath, Map<String, List<String>> parameters, Class<?>... outputClass) throws IOException, DataverseException {
+        return get(subPath, parameters, Collections.emptyMap(), outputClass);
+    }
+
+    public <D> DataverseHttpResponse<D> get(Path subPath, Map<String, List<String>> parameters, Map<String, String> headers, Class<?>... outputClass) throws IOException, DataverseException {
         HttpGet get = new HttpGet(buildURi(subPath, parameters));
+        headers.forEach(get::setHeader);
         return wrap(dispatch(get), outputClass);
     }
 


### PR DESCRIPTION
NO JIRA

# Description of changes
Added 'extraHeaders' to DatasetApi GET operations as well. Currently 'extraHeaders' only contains the invocation ID of a workflow. It is however needed for GET to retrieve for example metadata of a :draft dataset


# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
