### PR TITLE
DD-882: versionNote allows deaccessioned datasets

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
@@ -30,6 +30,7 @@ public class DatasetVersion {
     private int versionNumber;
     private int versionMinorNumber;
     private String versionState; // TODO: to enum
+    private String versionNote; // TODO: to enum
     private String unf;
     private String lastUpdateTime; // TODO: timestamp?
     private String releaseTime; // TODO: timestamp?
@@ -100,6 +101,14 @@ public class DatasetVersion {
 
     public void setVersionState(String versionState) {
         this.versionState = versionState;
+    }
+
+    public String getVersionNote() {
+        return versionNote;
+    }
+
+    public void setVersionNote(String versionNote) {
+        this.versionNote = versionNote;
     }
 
     @JsonProperty("UNF")


### PR DESCRIPTION
Fixes DD-882: versionNote allows deaccessioned datasets

# Description of changes


# How to test

Build into dd-verify-migration and run load-from-dataverse on a dataverse with at least one published and one deaccessioned dataset. Note that the token in the config.yml must be of an admin user.

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
