### PR TITLE
DD-1064 + DD-999: part 5 - new methods called by dd-ingest-flow

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAddFile.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAddFile.java
@@ -22,10 +22,8 @@ import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 public class DatasetAddFile extends ExampleBase {
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
@@ -18,16 +18,19 @@ package nl.knaw.dans.lib.dataverse.example;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
+import nl.knaw.dans.lib.dataverse.model.Role;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public class DataverseListRoles extends ExampleBase {
 
     private static final Logger log = LoggerFactory.getLogger(DataverseListRoles.class);
 
     public static void main(String[] args) throws Exception {
-        DataverseHttpResponse<DataMessage> r = client.dataverse("root").listRoles();
+        DataverseHttpResponse<List<Role>> r = client.dataverse("root").listRoles();
         log.info(r.getEnvelopeAsString());
-
+        log.info("envelope data name: " + r.getEnvelope().getData().get(0).getName());
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -72,6 +72,11 @@ public class DatasetApi extends AbstractTargetedApi {
         return getUnversionedFromTarget("", DatasetLatestVersion.class);
     }
 
+    public DataverseResponse<DatasetVersion> view() throws IOException, DataverseException {
+        // Not specifying a version results in getting all versions.
+        return getVersionedFromTarget("", Version.LATEST.toString(), DatasetVersion.class);
+    }
+
     /**
      * See [Dataverse API Guide].
      *

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,14 @@ public class DatasetApi extends AbstractTargetedApi {
         parameters.put("persistentId", singletonList(id));
         parameters.put("type", singletonList("major"));
         return httpClientWrapper.postJsonString(path, "", parameters, emptyMap(), DatasetPublicationResult.class);
+    }
+
+    public DataverseHttpResponse<DataMessage> publish(String updateType, boolean assureIsIndexed) throws IOException, DataverseException {
+        log.trace("ENTER");
+        HashMap<String, List<String>> parameters = new HashMap<>();
+        parameters.put("assureIsIndexed", singletonList(String.valueOf(assureIsIndexed)));
+        parameters.put("type", singletonList(updateType));
+        return httpClientWrapper.postJsonString(subPath(publish), "", params(parameters), new HashMap<>(), DataMessage.class);
     }
 
     public DataverseResponse<DatasetPublicationResult> releaseMigrated(String publicationDateJsonLd, boolean assureIsIndexed) throws IOException, DataverseException {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -24,6 +24,7 @@ import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.FieldList;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
+import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
@@ -122,11 +123,11 @@ public class DatasetApi extends AbstractTargetedApi {
         return httpClientWrapper.postJsonString(path, "", parameters, emptyMap(), DatasetPublicationResult.class);
     }
 
-    public DataverseHttpResponse<DataMessage> publish(String updateType, boolean assureIsIndexed) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> publish(UpdateType updateType, boolean assureIsIndexed) throws IOException, DataverseException {
         log.trace("ENTER");
         HashMap<String, List<String>> parameters = new HashMap<>();
         parameters.put("assureIsIndexed", singletonList(String.valueOf(assureIsIndexed)));
-        parameters.put("type", singletonList(updateType));
+        parameters.put("type", singletonList(updateType.toString()));
         return httpClientWrapper.postJsonString(subPath(publish), "", params(parameters), new HashMap<>(), DataMessage.class);
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -116,6 +116,11 @@ public class DatasetApi extends AbstractTargetedApi {
         return httpClientWrapper.postJsonString(path, "", parameters, emptyMap(), DatasetPublicationResult.class);
     }
 
+    public DataverseResponse<DatasetPublicationResult> releaseMigrated(String publicationDateJsonLd, boolean assureIsIndexed) throws IOException, DataverseException {
+        Map<String, List<String>> parameters = singletonMap("assureIsIndexed", singletonList(String.valueOf(assureIsIndexed)));
+        return httpClientWrapper.postJsonLdString(subPath("actions/:releasemigrated"), publicationDateJsonLd, params(parameters), emptyMap(), DatasetPublicationResult.class);
+    }
+
     /**
      * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
      * Replaces existing data.

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -278,7 +278,7 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        throw new UnsupportedOperationException();
+        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset,Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
     }
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -19,8 +19,6 @@ import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.Role;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignment;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
-import nl.knaw.dans.lib.dataverse.model.dataset.DatasetCreationResult;
-import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlockSummary;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import org.slf4j.Logger;
@@ -32,11 +30,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 
 /**
  * API end-points that operate on a dataverse collection.
@@ -136,9 +129,9 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-roles-defined-in-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> listRoles() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<Role>> listRoles() throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.get(subPath.resolve("roles"), DataMessage.class);
+        return httpClientWrapper.get(subPath.resolve("roles"), List.class, Role.class);
     }
 
     /**
@@ -234,9 +227,11 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection
      */
-    public DataverseHttpResponse<List<MetadataBlockSummary>> listMetadataBlocks() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> listMetadataBlocks() throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);    }
+        // TODO: implement
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * See [Dataverse API Guide].
@@ -275,9 +270,10 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
      */
-    public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> createDataset(String dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset,Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
+        // TODO: implement
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -285,7 +281,7 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
      */
-    public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> createDataset(Dataset dataset) throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
@@ -296,18 +292,10 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> importDataset() throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
-    }
-
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
-        log.trace("ENTER");
-        Map<String, List<String>> parameters = new HashMap<>();
-        optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
-        optPersistentId.ifPresent(pid -> parameters.put("pid", singletonList(pid)));
-        return httpClientWrapper.postJsonString(subPath.resolve("datasets/:import"), dataset, parameters, emptyMap(), DatasetCreationResult.class);
     }
 
     /**
@@ -315,7 +303,7 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-installation-with-a-ddi-file
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDatasetFromDdi() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> importDatasetFromDdi() throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -19,6 +19,8 @@ import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.Role;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignment;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetCreationResult;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlockSummary;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import org.slf4j.Logger;
@@ -30,6 +32,11 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 
 /**
  * API end-points that operate on a dataverse collection.
@@ -227,11 +234,9 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> listMetadataBlocks() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<MetadataBlockSummary>> listMetadataBlocks() throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
-    }
+        return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);    }
 
     /**
      * See [Dataverse API Guide].
@@ -270,10 +275,9 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> createDataset(String dataset) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
+        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset,Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
     }
 
     /**
@@ -281,7 +285,7 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> createDataset(Dataset dataset) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset) throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
@@ -292,10 +296,18 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> importDataset() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> importDataset() throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
+    }
+
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
+        log.trace("ENTER");
+        Map<String, List<String>> parameters = new HashMap<>();
+        optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
+        optPersistentId.ifPresent(pid -> parameters.put("pid", singletonList(pid)));
+        return httpClientWrapper.postJsonString(subPath.resolve("datasets/:import"), dataset, parameters, emptyMap(), DatasetCreationResult.class);
     }
 
     /**
@@ -303,7 +315,7 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-installation-with-a-ddi-file
      */
-    public DataverseHttpResponse<DataMessage> importDatasetFromDdi() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> importDatasetFromDdi() throws IOException, DataverseException {
         log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.lib.dataverse.model.Role;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignment;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetCreationResult;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlockSummary;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import org.slf4j.Logger;
@@ -233,11 +234,9 @@ public class DataverseApi extends AbstractApi {
      *
      * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection
      */
-    public DataverseHttpResponse<DataMessage> listMetadataBlocks() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<MetadataBlockSummary>> listMetadataBlocks() throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
-    }
+        return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);    }
 
     /**
      * See [Dataverse API Guide].

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
@@ -22,11 +22,16 @@ import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Object that lets your code talk to a Dataverse server.
  */
 public class DataverseClient {
+    private static final Logger logger = LoggerFactory.getLogger(DataverseClient.class);
 
     private final HttpClientWrapper httpClientWrapper;
     private SearchApi searchApi;
@@ -58,6 +63,12 @@ public class DataverseClient {
         module.addDeserializer(ResultItem.class, new ResultItemDeserializer(mapper));
         mapper.registerModule(module);
         this.httpClientWrapper = new HttpClientWrapper(config, httpClient == null ? HttpClients.createDefault() : httpClient, mapper);
+    }
+
+    public void checkConnection() throws IOException, DataverseException {
+        logger.info("Checking if root dataverse can be reached...");
+        dataverse("root").view().getData();
+            logger.info("OK: root dataverse is reachable.");
     }
 
     public WorkflowsApi workflows() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseItemDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseItemDeserializer.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.lib.dataverse;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -39,7 +38,7 @@ public class DataverseItemDeserializer extends StdDeserializer {
     }
 
     @Override
-    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonNode node = p.getCodec().readTree(p);
         String dataverseItemType = node.get("type").asText();
         if (DataverseItemType.dataverse.toString().equals(dataverseItemType)) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemDeserializer.java
@@ -130,7 +130,7 @@ public class ResultItemDeserializer extends StdDeserializer {
     // Generic getter for "objects", currently only used for the mysterious field "publications"
     private List<Map<Object, Object>> getListOfObjects(JsonNode node, String name) throws JsonProcessingException {
         JavaType t = mapper.getTypeFactory().constructParametricType(List.class, Map.class);
-        // writing the node to String and and then parsing it back again seems to be the only way for parametric types.
+        // writing the node to String and then parsing it back again seems to be the only way for parametric types.
         if (node.get(name) == null)
             return null;
         else

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/Version.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/Version.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+public enum Version {
+    DRAFT(":draft"),
+    LATEST(":latest"),
+    LATEST_PUBLISHED(":latest-published");
+
+    public String toString() {
+        return stringValue;
+    }
+
+    private final String stringValue;
+
+    private Version(String stringValue) {
+        this.stringValue = stringValue;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelope.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelope.java
@@ -18,7 +18,7 @@ package nl.knaw.dans.lib.dataverse.model;
 public class DataverseEnvelope<D> {
 
     private String status;
-    private String message;
+    private DataMessage message;
     private D data;
 
     public String getStatus() {
@@ -29,11 +29,11 @@ public class DataverseEnvelope<D> {
         this.status = status;
     }
 
-    public String getMessage() {
+    public DataMessage getMessage() {
         return message;
     }
 
-    public void setMessage(String message) {
+    public void setMessage(DataMessage message) {
         this.message = message;
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.dataset;
+
+public class Embargo {
+    private String dateAvailable;
+    private String reason;
+    private int[] fileIds;
+
+    public Embargo(String dateAvailable, String reason, int[] fileIds) {
+        this.dateAvailable = dateAvailable;
+        this.reason = reason;
+        this.fileIds = fileIds;
+    }
+
+    public String getDateAvailable() {
+        return dateAvailable;
+    }
+
+    public void setDateAvailable(String dateAvailable) {
+        this.dateAvailable = dateAvailable;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public int[] getFileIds() {
+        return fileIds;
+    }
+
+    public void setFileIds(int[] fileIds) {
+        this.fileIds = fileIds;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlockSummary.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlockSummary.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.dataset;
+
+public class MetadataBlockSummary {
+    int id;
+    String name;
+    String displayName;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/UpdateType.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/UpdateType.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model.dataset;
+
+public enum UpdateType { major, minor}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/Dataverse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/Dataverse.java
@@ -28,7 +28,16 @@ public class Dataverse {
     private DataverseType dataverseType;
     private String storageDriverLabel;
     private String creationDate;
+    private DataverseTheme theme;
     private List<DataverseContact> dataverseContacts;
+
+    public DataverseTheme getTheme() {
+        return theme;
+    }
+
+    public void setTheme(DataverseTheme theme) {
+        this.theme = theme;
+    }
 
     public int getId() {
         return id;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
@@ -1,0 +1,31 @@
+package nl.knaw.dans.lib.dataverse.model.dataverse;
+
+public class DataverseTheme {
+    int id;
+    String logo;
+    String logoBackgroundColor;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+    public void setLogo(String logo) {
+        this.logo = logo;
+    }
+
+    public String getLogoBackgroundColor() {
+        return logoBackgroundColor;
+    }
+
+    public void setLogoBackgroundColor(String logoBackgroundColor) {
+        this.logoBackgroundColor = logoBackgroundColor;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
 public class DataverseTheme {

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/AddFileTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/AddFileTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
+import nl.knaw.dans.lib.dataverse.model.ModelFixture;
+import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
+import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AddFileTest extends ModelFixture {
+
+    private static class AddFile extends DataverseEnvelope<FileList> {
+    }
+
+    private static final Class<AddFile> wrappedClassUnderTest = AddFile.class;
+    private final File jsonFile = getTestJsonFileFor(wrappedClassUnderTest);
+
+    @Test
+    public void canDeserialize() throws Exception {
+        assertEquals(
+                "PAN-00016988-001-copy.jpg",
+                mapper.readValue(jsonFile, wrappedClassUnderTest).getData().getFiles().get(0).getLabel()
+        );
+    }
+
+    @Test
+    public void roundTrip() throws Exception {
+        assertEquals(
+                "This file has the same content as PAN-00016988-001-copy.jpg that is in the dataset.",
+                roundTrip(jsonFile, wrappedClassUnderTest).getMessage().getMessage().trim()
+        );
+    }
+}

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/EnvelopeMessageTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/EnvelopeMessageTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
+import nl.knaw.dans.lib.dataverse.model.ModelFixture;
+import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EnvelopeMessageTest extends ModelFixture {
+
+    private static class EnvelopeMessage extends DataverseEnvelope<FileList> {
+    }
+
+    private static final Class<EnvelopeMessage> wrappedClassUnderTest = EnvelopeMessage.class;
+    private final File jsonFile = getTestJsonFileFor(wrappedClassUnderTest);
+
+    @Test
+    public void canDeserialize() throws Exception {
+        // TODO a DataverseEnvelopeDeserializer?
+        //  it should allow message as either a String or a DataMessage as in AddFile.json?
+        //  it needs to support the generic data field
+        assertThrows(MismatchedInputException.class, () -> mapper.readValue(jsonFile, wrappedClassUnderTest),
+            "Cannot construct instance of `nl.knaw.dans.lib.dataverse.model.DataMessage` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('This message is just hypothetical')\n"
+                + " at [Source: (File); line: 3, column: 14] (through reference chain: nl.knaw.dans.lib.dataverse.AddFile2Test$AddFile2[\"message\"])");
+    }
+}

--- a/lib/src/test/resources/model/AddFile.json
+++ b/lib/src/test/resources/model/AddFile.json
@@ -1,0 +1,34 @@
+{
+  "status": "OK",
+  "message": {
+    "message": "This file has the same content as PAN-00016988-001-copy.jpg that is in the dataset. "
+  },
+  "data": {
+    "files": [
+      {
+        "description": "",
+        "label": "PAN-00016988-001-copy.jpg",
+        "restricted": false,
+        "directoryLabel": "images",
+        "version": 1,
+        "datasetVersionId": 513,
+        "dataFile": {
+          "id": 4062,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "PAN-00016988-001-copy.jpg",
+          "contentType": "image/jpeg",
+          "filesize": 612553,
+          "description": "",
+          "storageIdentifier": "file://181fb83880a-3a223fb5a977",
+          "rootDataFileId": -1,
+          "checksum": {
+            "type": "SHA-1",
+            "value": "0d3b4162c0d797384c6fb87778ade0d843307dea"
+          },
+          "creationDate": "2022-07-14"
+        }
+      }
+    ]
+  }
+}

--- a/lib/src/test/resources/model/EnvelopeMessage.json
+++ b/lib/src/test/resources/model/EnvelopeMessage.json
@@ -1,0 +1,32 @@
+{
+  "status": "OK",
+  "message": "This message is just hypothetical",
+  "data": {
+    "files": [
+      {
+        "description": "",
+        "label": "PAN-00016988-001-copy.jpg",
+        "restricted": false,
+        "directoryLabel": "images",
+        "version": 1,
+        "datasetVersionId": 513,
+        "dataFile": {
+          "id": 4062,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "PAN-00016988-001-copy.jpg",
+          "contentType": "image/jpeg",
+          "filesize": 612553,
+          "description": "",
+          "storageIdentifier": "file://181fb83880a-3a223fb5a977",
+          "rootDataFileId": -1,
+          "checksum": {
+            "type": "SHA-1",
+            "value": "0d3b4162c0d797384c6fb87778ade0d843307dea"
+          },
+          "creationDate": "2022-07-14"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes DD-1064 + DD-999: part 4 - new methods called by dd-ingest-flow

# Description of changes

* last required API calls except `DataverseClient.checkConnection`
* fixed c83a4931 as reported in [DD-1064](https://drivenbydata.atlassian.net/browse/DD-1064):
  message is not a plain String in `{"status":"OK","message":{"message"`
* [x] compile related pull request with fix for DD-1064 and beyond
* [x] fix EnvelopeMessageTest (support both plain string and object with string)
* [ ] execute a health check with the related pull request:
  * [x]  http://dar.dans.knaw.nl:20301/healthcheck
  * [ ] check for the logging with the proper package (dataverse, not scaladv) https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/3309485fb4f02e88e181b7eb4723193c949b50e3/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java#L69
    tried with `config.yml`:

        logging:
          level: WARN
          loggers:
            "nl.knaw.dans":
              level: TRACE
            "nl.knaw.dans.ingest.core.service.UnboundedDepositsImportTaskIterator":
              level: INFO



# How to test

With related pull request

# Related PRs 

* https://github.com/DANS-KNAW/dd-ingest-flow/pull/24

# Notify
@DANS-KNAW/dataversedans
