### PR TITLE
Fixing JavaDocs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,21 @@ on:
       - master
 
 jobs:
-   build:
-     runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-     steps:
-       - uses: actions/checkout@v2
-       - name: Set up JDK 8
-         uses: actions/setup-java@v1
-         with:
-           java-version: 8
-       - name: Cache local Maven repository
-         uses: actions/cache@v2
-         with:
-           path: ~/.m2/repository
-           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-           restore-keys: |
-             ${{ runner.os }}-maven-
-       - name: Build with Maven
-         run: mvn -B package --file pom.xml
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -22,7 +22,9 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up Python
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
@@ -34,8 +36,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
-      - name: Build with Maven
-        run: mvn -B install --file lib/pom.xml
       - name: Run script
         run: bash .github/workflows/mkdocs/mkdocs.sh
         shell: bash

--- a/add-javadocs.sh
+++ b/add-javadocs.sh
@@ -21,4 +21,9 @@ mvn javadoc:javadoc
 
 if [ -d "docs/javadocs" ]; then rm -fr docs/javadocs; fi
 mv lib/target/site/apidocs docs/javadocs
+
+echo "Set useModuleDirectories = false..."
+sed -i '' 's/^.*useModuleDirectories = true.*$/var useModuleDirectories = false;/' 'docs/javadocs/index.html'
 echo "DONE build and add javadocs"
+
+

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,19 +20,19 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
-        <artifactId>dans-java-project</artifactId>
-        <version>7.4.0</version>
-        <relativePath />
+        <artifactId>dans-dropwizard-project</artifactId>
+        <version>7.5.0</version>
+        <relativePath/>
     </parent>
     <groupId>nl.knaw.dans</groupId>
     <artifactId>dans-dataverse-client-lib-examples</artifactId>
     <version>0.1.2-SNAPSHOT</version>
     <name>DANS Dataverse Client Library Examples</name>
     <inceptionYear>2021</inceptionYear>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
+    <scm>
+        <tag>HEAD</tag>
+        <developerConnection>scm:git:https://github.com/DANS-KNAW/dans-dataverse-client-lib</developerConnection>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>nl.knaw.dans</groupId>
@@ -78,20 +78,7 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
-
-  <scm>
-    <tag>HEAD</tag>
-    <developerConnection>scm:git:https://github.com/DANS-KNAW/dans-dataverse-client-lib</developerConnection>
-  </scm>
 </project>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -114,6 +114,12 @@
                     <linksource>false</linksource>
                     <bottom><![CDATA[Copyright ${project.inceptionYear}, <a href="http://www.dans.knaw.nl">DANS<a>]]></bottom>
                     <additionalJOptions>
+                        <!-- -J-version prints the Java version used. Sometimes the following warnings appear
+
+                          javadoc: warning - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
+
+                          This suggests that Java 8 is sometimes used.
+                         -->
                         <additionalJOption>-J-version</additionalJOption>
                         <additionalJOption>-J-Xmx1g</additionalJOption>
                         <additionalJOption>-J-Djava.awt.headless=true</additionalJOption>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -105,6 +105,37 @@
                     <target>11</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <linksource>false</linksource>
+                    <bottom><![CDATA[Copyright ${project.inceptionYear}, <a href="http://www.dans.knaw.nl">DANS<a>]]></bottom>
+                    <additionalJOptions>
+                        <additionalJOption>-J-version</additionalJOption>
+                        <additionalJOption>-J-Xmx1g</additionalJOption>
+                        <additionalJOption>-J-Djava.awt.headless=true</additionalJOption>
+                    </additionalJOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadoc</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>aggregate</id>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -16,19 +16,24 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
-        <artifactId>dans-java-project</artifactId>
-        <version>7.4.0</version>
-        <relativePath />
+        <artifactId>dans-dropwizard-project</artifactId>
+        <version>7.5.0</version>
+        <relativePath/>
     </parent>
     <groupId>nl.knaw.dans</groupId>
     <artifactId>dans-dataverse-client-lib</artifactId>
     <version>0.1.2-SNAPSHOT</version>
     <name>DANS Dataverse Client Library</name>
     <inceptionYear>2021</inceptionYear>
+    <scm>
+        <tag>HEAD</tag>
+        <developerConnection>scm:git:https://github.com/DANS-KNAW/dans-dataverse-client-lib</developerConnection>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -41,7 +46,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.12</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -93,44 +98,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>build-javadocs</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <jdk>1.8.0</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <skip>false</skip>
-                            <doclet>ch.raffael.doclets.pegdown.PegdownDoclet</doclet>
-                            <docletArtifact>
-                                <groupId>ch.raffael.pegdown-doclet</groupId>
-                                <artifactId>pegdown-doclet</artifactId>
-                                <version>1.1</version>
-                            </docletArtifact>
-                            <useStandardDocletOptions>true</useStandardDocletOptions>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
-  <scm>
-    <tag>HEAD</tag>
-    <developerConnection>scm:git:https://github.com/DANS-KNAW/dans-dataverse-client-lib</developerConnection>
-  </scm>
 </project>
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
@@ -25,11 +25,9 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
- * API end-points that operate on a dataverse collection.
+ * Administration API end-points.
  *
- * See [Dataverse API Guide].
- *
- * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#dataverse-collections
+ * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#admin" target="_blank">Dataverse documentation</a>
  */
 public class AdminApi extends AbstractApi {
 
@@ -43,9 +41,11 @@ public class AdminApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-single-user
+     * @param id username
+     * @return the user
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-single-user" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<AuthenticatedUser> listSingleUser(String id) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "authenticatedUsers", id);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * See [Dataverse API Guide].
+ * Basic file access API end-points.
  *
- * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access
+ * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
  */
 public class BasicFileAccessApi extends AbstractTargetedApi {
     protected BasicFileAccessApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
@@ -35,56 +35,44 @@ public class BasicFileAccessApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access
-     *
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse getFile() throws DataverseException, IOException {
         return getFile(null, null);
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access
-     *
-     * @param range the range of the file to return, see https://guides.dataverse.org/en/latest/api/dataaccess.html#headers
+     * @param range the range of the file to return, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#headers" target="_blank">Dataverse documentation</a>
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse getFile(GetFileRange range) throws DataverseException, IOException {
         return getFile(null, range);
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access
-     *
-     * @param options the request options, see https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters
+     * @param options the request options, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters" target="_blank"></a>Dataverse documentation</a>
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse getFile(GetFileOptions options) throws DataverseException, IOException {
         return getFile(options, null);
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access
-     *
-     * @param options the request options, see https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters
-     * @param range   the range of the file to return, see https://guides.dataverse.org/en/latest/api/dataaccess.html#headers
+     * @param options the request options, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters" target="_blank">Dataverse documentation</a>
+     * @param range   the range of the file to return, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#headers" target="_blank">Dataverse documentation</a>
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse getFile(GetFileOptions options, GetFileRange range) throws DataverseException, IOException {
         HashMap<String, List<String>> params = new HashMap<>();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
@@ -56,7 +56,7 @@ public class BasicFileAccessApi extends AbstractTargetedApi {
     }
 
     /**
-     * @param options the request options, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters" target="_blank"></a>Dataverse documentation</a>
+     * @param options the request options, see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#parameters" target="_blank">Dataverse documentation</a>
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -82,7 +82,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * Retrieves that latest version of a dataset. The difference with {@link #getLatestVersion()} is that the latter returns a different type
      * of object. It is not clear why these variants exist.
      *
-     * @return object containing the Dataset version metadata
+     * @return object containing the dataset version metadata
      * @throws IOException        if an I/O exception occurs
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
@@ -94,6 +94,9 @@ public class DatasetApi extends AbstractTargetedApi {
 
     /**
      * @param version version to retrieve
+     * @return object containing the dataset version metadata
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> getVersion(String version) throws IOException, DataverseException {
@@ -103,6 +106,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
+     * @return list of objects containing dataset version metadata
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-versions-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<List<DatasetVersion>> getAllVersions() throws IOException, DataverseException {
@@ -111,6 +117,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
+     * @return a list of file metas
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
      * @param version version to get file metadata from
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
@@ -120,6 +129,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
+     * @return dataset publication result
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetPublicationResult> publish() throws IOException, DataverseException {
@@ -216,6 +228,7 @@ public class DatasetApi extends AbstractTargetedApi {
 
     /**
      * @param metadata JSON document describing the metadata
+     * @param replace replace existing metadata
      * @return a generic DataverseResponse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -409,6 +422,8 @@ public class DatasetApi extends AbstractTargetedApi {
 
     /**
      * @return a list of locks
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks" target="_blank">...</a>
      * @see <a href="https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/master/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java">Code example</a>
      */
@@ -426,6 +441,8 @@ public class DatasetApi extends AbstractTargetedApi {
      *
      * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
      * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
      */
     public void awaitUnlock(int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException {
         log.trace(String.format("awaitUnlock: maxNumberOfRetries %d, waitTimeInMilliseconds %d", maxNumberOfRetries, waitTimeInMilliseconds));
@@ -452,6 +469,8 @@ public class DatasetApi extends AbstractTargetedApi {
      * @param lockType               the lock type to wait for
      * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to #awawaitLockStateMaxNumberOfRetries
      * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
      */
     public void awaitLock(String lockType, int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException {
         log.trace(String.format("awaitLock: lockType %s, maxNumberOfRetries %d, waitTimeInMilliseconds %d", lockType, maxNumberOfRetries, waitTimeInMilliseconds));

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -48,6 +48,11 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
+/**
+ * API end-points dealing with a single dataset.
+ *
+ * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#datasets" target="_blank">Dataverse documentation</a>
+ */
 public class DatasetApi extends AbstractTargetedApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
@@ -64,23 +69,23 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#get-json-representation-of-a-dataset
-     *
      * @return a JSON object that starts at the dataset level, most fields are replicated at the dataset version level.
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-json-representation-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetLatestVersion> getLatestVersion() throws IOException, DataverseException {
         return getUnversionedFromTarget("", DatasetLatestVersion.class);
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
      * Retrieves that latest version of a dataset. The difference with {@link #getLatestVersion()} is that the latter returns a different type
      * of object. It is not clear why these variants exist.
      *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset
+     * @return object containing the Dataset version metadata
+     * @throws IOException        if an I/O exception occurs
+     * @throws DataverseException if Dataverse could not handle the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> getVersion() throws IOException, DataverseException {
         // Not specifying a version results in getting all versions.
@@ -88,9 +93,8 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset
+     * @param version version to retrieve
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> getVersion(String version) throws IOException, DataverseException {
         if (StringUtils.isBlank(version))
@@ -98,11 +102,8 @@ public class DatasetApi extends AbstractTargetedApi {
         return getVersionedFromTarget("", version, DatasetVersion.class);
     }
 
-
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-versions-of-a-dataset
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-versions-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<List<DatasetVersion>> getAllVersions() throws IOException, DataverseException {
         // Not specifying a version results in getting all versions.
@@ -110,9 +111,8 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * @param version [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset
+     * @param version version to get file metadata from
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<List<FileMeta>> getFiles(String version) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -120,9 +120,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetPublicationResult> publish() throws IOException, DataverseException {
         Path path = buildPath(targetBase, persistendId, publish);
@@ -146,30 +144,29 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
-     * Replaces existing data.
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
+     * multiple values.
      *
      * @param s JSON document containing the edits to perform
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(String s) throws IOException, DataverseException {
         return editMetadata(s, true);
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
+     * multiple values.
      *
      * @param s       JSON document containing the edits to perform
      * @param replace whether to replace existing values
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -184,15 +181,15 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
+     * multiple values.
      *
      * @param fields  list of fields to edit
      * @param replace whether to replace existing values
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), replace);
@@ -201,12 +198,11 @@ public class DatasetApi extends AbstractTargetedApi {
     /**
      * Edits the current draft's metadata, adding the fields that do not exist yet.
      *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata
-     *
      * @param fields list of fields to edit
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), true);
@@ -219,14 +215,11 @@ public class DatasetApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#list-single-metadata-block-for-a-dataset
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata
-     *
      * @param metadata JSON document describing the metadata
-     * @return
+     * @return a generic DataverseResponse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace) throws IOException, DataverseException {
         Map<String, List<String>> queryParams = singletonMap("replace", singletonList((String.valueOf(replace))));
@@ -234,14 +227,11 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset
-     *
      * @param s JSON document containing the new metadata
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> updateMetadata(String s) throws IOException, DataverseException {
         // Cheating with endPoint here, because the only version that can be updated is :draft anyway
@@ -249,14 +239,11 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset
-     *
      * @param metadataBlocks map of metadata block name to metadata block
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks) throws IOException, DataverseException {
         return updateMetadata(httpClientWrapper.writeValueAsString(singletonMap("metadataBlocks", metadataBlocks)));
@@ -265,13 +252,10 @@ public class DatasetApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-metadata
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft
-     *
-     * @return
+     * @return a data message
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DataMessage> deleteDraft() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -282,13 +266,10 @@ public class DatasetApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#revert-citation-date-field-type-to-default-for-dataset
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-role-assignments-on-a-dataverse-api
-     *
-     * @return
+     * @return role assignment information
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-role-assignments-on-a-dataverse-api" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<RoleAssignmentReadOnly>> listRoleAssignments() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -296,14 +277,11 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataset
-     *
      * @param roleAssignment JSON document describing the assignment
-     * @return
+     * @return role assignment information
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<RoleAssignmentReadOnly> assignRole(String roleAssignment) throws IOException, DataverseException {
         return httpClientWrapper.postJsonString(subPath("assignments"), roleAssignment, params(emptyMap()), extraHeaders, RoleAssignmentReadOnly.class);
@@ -315,13 +293,12 @@ public class DatasetApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-the-private-url-from-a-dataset
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset
-     *
      * @param file     the file to add
      * @param metadata json document with the file metadata
-     * @return DatasetVersion
+     * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<FileList> addFile(Path file, String metadata) throws IOException, DataverseException {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
@@ -331,28 +308,26 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset
-     *
      * @param file     the file to add
      * @param fileMeta json document with the file metadata
-     * @return DatasetVersion
+     * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<FileList> addFile(Path file, FileMeta fileMeta) throws IOException, DataverseException {
         return addFile(file, httpClientWrapper.writeValueAsString(fileMeta));
     }
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset
-     *
-     * At least one of the parameters should be provided.
-     *
      * @param optDataFile     content of the file
      * @param optFileMetadata metadata of the file
-     * @return
+     * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
+     *
+     * At least one of the parameters should be provided.
      */
     public DataverseHttpResponse<FileList> addFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
         log.trace("{} {}", optDataFile, optFileMetadata);
@@ -395,13 +370,13 @@ public class DatasetApi extends AbstractTargetedApi {
      */
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#set-an-embargo-on-files-in-a-dataset
-     *
      * @param json the embargo data
-     * @return
+     * @return a hash map
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#set-an-embargo-on-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
+    // TODO: can the hash map be converted to a more specific object?
     public DataverseHttpResponse<HashMap> setEmbargo(String json) throws IOException, DataverseException {
         return httpClientWrapper.postJsonString(subPath("files/actions/:set-embargo"), json, params(emptyMap()), extraHeaders, HashMap.class);
     }
@@ -433,9 +408,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * See [Dataverse API Guide] and [code example]
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks [code example]: https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/master/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
+     * @return a list of locks
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks" target="_blank">...</a>
+     * @see <a href="https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/master/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java">Code example</a>
      */
     public DataverseResponse<List<Lock>> getLocks() throws IOException, DataverseException {
         log.trace("getting locks from Dataverse");
@@ -443,8 +418,10 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions in this library, this does not correspond directly with an API call. Rather the
-     * {@link #getLocks()} call is done repeatedly to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset it is not guaranteed that
+     * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions in this library, this does not correspond directly with an API
+     * call. Rather the
+     * {@link #getLocks()} call is done repeatedly to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset it is
+     * not guaranteed that
      * the locks, once cleared, stay that way.
      *
      * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
@@ -466,8 +443,10 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Utility function that lets you wait until a specified lock type is set. Unlike most other functions in this library, this does not correspond directly with an API call. Rather the {@link
-     * #getLocks()} call is done repeatedly to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been locked on its behalf, so that it can
+     * Utility function that lets you wait until a specified lock type is set. Unlike most other functions in this library, this does not correspond directly with an API call.
+     * Rather the {@link
+     * #getLocks()} call is done repeatedly to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been locked on its
+     * behalf, so that it can
      * be sure to have exclusive access via its invocation ID.
      *
      * @param lockType               the lock type to wait for
@@ -511,7 +490,8 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs within `maxNumberOrRetries` with `waitTimeInMilliseconds`
+     * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs within `maxNumberOrRetries` with
+     * `waitTimeInMilliseconds`
      * pauses.
      *
      * @param lockState              the function that returns whether the required state has been reached

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -41,9 +41,7 @@ import static java.util.Collections.singletonList;
 /**
  * API end-points that operate on a dataverse collection.
  *
- * See [Dataverse API Guide].
- *
- * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#dataverse-collections
+ * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#dataverse-collections" target="_blank">Dataverse documentation</a>
  */
 public class DataverseApi extends AbstractApi {
 
@@ -58,14 +56,11 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection
-     *
      * @param dataverse dataverse to create
      * @return description of the dataverse just created
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> create(String dataverse) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -73,14 +68,11 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection
-     *
      * @param dataverse dataverse to create
      * @return description of the dataverse just created
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> create(Dataverse dataverse) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -88,13 +80,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#view-a-dataverse-collection
-     *
      * @return Information about a dataverse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#view-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> view() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -102,9 +91,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#delete-a-dataverse-collection
+     * @return a generic response
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#delete-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> delete() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -112,9 +102,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#show-contents-of-a-dataverse-collection
+     * @return a list of information items about subverses
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#show-contents-of-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<DataverseItem>> getContents() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -122,9 +113,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#report-the-data-file-size-of-a-dataverse-collection
+     * @return a data message containing information about the storage size
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#report-the-data-file-size-of-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> getStorageSize() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -132,9 +124,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-roles-defined-in-a-dataverse-collection
+     * @return a list of roles
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-roles-defined-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<Role>> listRoles() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -142,9 +135,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-facets-configured-for-a-dataverse-collection
+     * @return a list of facets
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-facets-configured-for-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> listFacets() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -152,10 +146,8 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#set-facets-for-a-dataverse-collection
+    /*
+     * https://guides.dataverse.org/en/latest/api/native-api.html#set-facets-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> setFacets(List<String> facets) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -163,10 +155,7 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> createRole(String role) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -174,10 +163,8 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
+    /*
+     *  https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> createRole(Role role) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -185,10 +172,7 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-role-assignments-in-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#list-role-assignments-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> listRoleAssignments() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -196,10 +180,8 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#assign-default-role-to-user-creating-a-dataset-in-a-dataverse-collection
+    /*
+     * https://guides.dataverse.org/en/latest/api/native-api.html#assign-default-role-to-user-creating-a-dataset-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> assignDefaultRoleOnDataset(String roleName) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -207,10 +189,8 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataverse-collection
+    /*
+     * https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> assignRole(RoleAssignment roleAssignment) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -218,10 +198,7 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#delete-role-assignment-from-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#delete-role-assignment-from-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> deleteRoleAssignment(int roleAssignmentId) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -230,18 +207,17 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection
+     * @return a list of metadata block summaries
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<MetadataBlockSummary>> listMetadataBlocks() throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);    }
+        return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);
+    }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#define-metadata-blocks-for-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#define-metadata-blocks-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> defineMetadataBlocks(List<String> metadataBlocks) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -250,9 +226,10 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#determine-if-a-dataverse-collection-inherits-its-metadata-blocks-from-its-parent
+     * @return <code>true</code> if this dataverse is a metadata blocks root, <code>false</code> otherwise
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#determine-if-a-dataverse-collection-inherits-its-metadata-blocks-from-its-parent" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Boolean> isMetadataBlocksRoot() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -260,30 +237,29 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#configure-a-dataverse-collection-to-inherit-its-metadata-blocks-from-its-parent
+     * @return a data message
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#configure-a-dataverse-collection-to-inherit-its-metadata-blocks-from-its-parent" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> setMetadataBlocksRoot(boolean isRoot) throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.putTextString(subPath.resolve("metadatablocks/isRoot"), Boolean.toString(isRoot),
-            Collections.emptyMap(), Collections.emptyMap(), DataMessage.class);
+        return httpClientWrapper.putTextString(subPath.resolve("metadatablocks/isRoot"), Boolean.toString(isRoot), Collections.emptyMap(), Collections.emptyMap(),
+            DataMessage.class);
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
+     * @return a creation result message
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset,Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
+        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset, Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset) throws IOException, DataverseException {
         log.trace("ENTER");
@@ -291,10 +267,7 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection
      */
     public DataverseHttpResponse<DatasetCreationResult> importDataset() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -302,7 +275,8 @@ public class DataverseApi extends AbstractApi {
         throw new UnsupportedOperationException();
     }
 
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish)
+        throws IOException, DataverseException {
         log.trace("ENTER");
         Map<String, List<String>> parameters = new HashMap<>();
         optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
@@ -310,10 +284,7 @@ public class DataverseApi extends AbstractApi {
         return httpClientWrapper.postJsonString(subPath.resolve("datasets/:import"), dataset, parameters, emptyMap(), DatasetCreationResult.class);
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-installation-with-a-ddi-file
+    /* https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-installation-with-a-ddi-file
      */
     public DataverseHttpResponse<DatasetCreationResult> importDatasetFromDdi() throws IOException, DataverseException {
         log.trace("ENTER");
@@ -322,19 +293,17 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataverse-collection
+     * @return a data message
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> publish() throws IOException, DataverseException {
         log.trace("ENTER");
         return httpClientWrapper.postJsonString(subPath.resolve(publish), "", new HashMap<>(), new HashMap<>(), DataMessage.class);
     }
 
-    /**
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#retrieve-guestbook-responses-for-a-dataverse-collection
+    /*https://guides.dataverse.org/en/latest/api/native-api.html#retrieve-guestbook-responses-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> getGuestBookResponses() throws IOException, DataverseException {
         log.trace("ENTER");

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -237,6 +237,7 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
+     * @param isRoot whether to make this dataverse collection a metadata blocks root
      * @return a data message
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -249,6 +250,7 @@ public class DataverseApi extends AbstractApi {
     }
 
     /**
+     * @param dataset JSON string defining the dataset to create
      * @return a creation result message
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
@@ -26,22 +26,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * Response from Dataverse. A typical response from Dataverse is a JSON document with the following format:
+ * Response from Dataverse.
  *
- * <!-- @formatter:off -->
- * ```json
- *  {
- *    "status": "OK",
- *    "data": {
- *        "myfield": "myvalue"
- *    }
- *  }
- * ```
- * <!-- @formatter:on -->
- *
- * {@link nl.knaw.dans.lib.dataverse.model}.
- *
- * @param <D> the type of the data of the response message envelope
+ * @param <D> the type of the data of the response message envelope, one of the classes in {@link nl.knaw.dans.lib.dataverse.model}
  */
 public class DataverseResponse<D> {
     private static final Logger log = LoggerFactory.getLogger(DataverseResponse.class);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
@@ -51,13 +51,12 @@ public class FileApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#adding-file-metadata
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files
-     *
-     * @param optDataFile
-     * @param optFileMetadata json
-     * @return
+     * @param optDataFile the data file
+     * @param optFileMetadata json containing file metadata
+     * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<FileList> replaceFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
         logger.trace("{} {}", optDataFile, optFileMetadata);
@@ -70,12 +69,11 @@ public class FileApi extends AbstractTargetedApi {
     }
 
     /**
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata
-     *
      * @param json the file metadata
-     * @return
+     * @return hash map
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<HashMap> updateMetadata(String json) throws IOException, DataverseException {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
@@ -39,14 +39,11 @@ public class SearchApi extends AbstractApi {
     /**
      * A basic search action with default options.
      *
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/search.html
-     *
      * @param query search query
      * @return a search result
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/search.html" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<SearchResult> find(String query) throws IOException, DataverseException {
         return find(query, new SearchOptions());
@@ -55,15 +52,12 @@ public class SearchApi extends AbstractApi {
     /**
      * A search action with specific {@link SearchOptions}.
      *
-     * See [Dataverse API Guide].
-     *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/search.html
-     *
      * @param query   search query
      * @param options further options for futher filtering and rendering the results
      * @return a search result
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/search.html" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<SearchResult> find(String query, SearchOptions options)
         throws IOException, DataverseException {
@@ -96,11 +90,11 @@ public class SearchApi extends AbstractApi {
         return new ResultItemIterator(this, query, searchOptions);
     }
 
-
     /**
-     * Returns an iterator to all the results for the specified query and default options. The caller is responsible for calling the {@link ResultItem}s to the appropriate subclass.
+     * Returns an iterator to all the results for the specified query and default options. The caller is responsible for calling the {@link ResultItem}s to the appropriate
+     * subclass.
      *
-     * @param query         the query to execute
+     * @param query the query to execute
      * @return an iterator over the results
      */
     public Iterator<ResultItem> iterator(String query) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
@@ -35,11 +35,12 @@ public class SwordApi extends AbstractApi {
     /**
      * Deletes a file from the current draft of the dataset.
      *
-     * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/sword.html#delete-a-file-by-database-id
-     *
      * @param databaseId the database ID of the file to delete.
-     *                   To look up use DatasetApi#listFiles.
-     * @return
+     *                   To look up use @{link DatasetApi#listFiles}.
+     * @return a generic http response
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/sword.html#delete-a-file-by-database-id" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse deleteFile(int databaseId) throws IOException, DataverseException {
         log.trace("ENTER");

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/package-info.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/package-info.java
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 /**
- * Main package for the DANS Dataverse Client Library
- * ==================================================
- *
+ * <h1>Main package for the DANS Dataverse Client Library</h1>
+ * <p>
  * The starting point to work with the libary is the class {@link nl.knaw.dans.lib.dataverse.DataverseClient}. It is instantiated with a
  * {@link nl.knaw.dans.lib.dataverse.DataverseClientConfig} to point it to a particular Dataverse server and provide it with the necessary credentials,
  * e.g. an API token.
- *
- * Dataverse's API is divided up into several endpoints that allow you to query and modify various entities on the server, such as dataverses, datasets, files,
- * user acounts, etc. The following example shows how you would retrieve the description for the root dataverse. The API token should of course be replaced with
- * a valid one, if you try this out.
- *
- * <!-- @formatter:off -->
- * ```java
- *  // Replace the second constructor argument with your Dataverse API token
- *  DataverseClientConfig config = new DataverseClientConfig(new URI("http://localhost:8080"), "d679391a-75bf-4735-a46a-2ff4a79b9919");
- *  DataverseClient client = new DataverseClient(config);
- *  DataverseHttpResponse<Dataverse> r = client.dataverse("root").view();
- *  System.out.println(r.getData().getDescription());
- * ```
- * <!-- @formatter:on -->
+ * </p>
  */
 package nl.knaw.dans.lib.dataverse;

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
                     <excludes>
                         <exclude>LICENSE</exclude>
                         <exclude>docs/</exclude>
+                        <exclude>venv/</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
NO JIRA

# Description of changes
* Upgrade to Java 11 source level
* Use JavaDoc for Java 11
* Fix problems with the Java 11 search function by setting `useModuleDirectories` to `false` in `index.html`.

# Notify
@DANS-KNAW/dataversedans
