### PR TITLE
DD-1061 Added invocationId parameter to all targeted APIs

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
@@ -31,11 +31,16 @@ abstract class AbstractTargetedApi extends AbstractApi {
     protected final String id;
     protected final boolean isPersistentId;
 
-    protected AbstractTargetedApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, Path targetBase) {
+    protected final Map<String, String> extraHeaders = new HashMap<>();
+
+
+    protected AbstractTargetedApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId, Path targetBase) {
         super(httpClientWrapper);
         this.id = id;
         this.isPersistentId = isPersistentId;
         this.targetBase = targetBase;
+        if (invocationId != null)
+            extraHeaders.put("X-Dataverse-invocationID", invocationId);
     }
 
     protected Map<String, List<String>> params(Map<String, List<String>> queryParams) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
@@ -31,8 +31,13 @@ import java.util.Optional;
  */
 public class BasicFileAccessApi extends AbstractTargetedApi {
     protected BasicFileAccessApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
-        super(httpClientWrapper, id, isPersistentId, Paths.get("api/access/datafile"));
+        super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/access/datafile"));
     }
+
+    protected BasicFileAccessApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId) {
+        super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/access/datafile"));
+    }
+
 
     /**
      * @return a HttpResponse object
@@ -87,7 +92,7 @@ public class BasicFileAccessApi extends AbstractTargetedApi {
         if (range != null) {
             headers.put("Range", "bytes=" + range.getStart() + "-" + range.getEnd());
         }
-
+        headers.putAll(extraHeaders);
         return httpClientWrapper.get(subPath(""), params, headers);
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
@@ -34,9 +34,15 @@ public class DataAccessRequestsApi extends AbstractTargetedApi {
     private final HashMap<String, String> headers = new HashMap<>();
 
     protected DataAccessRequestsApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
-        super(httpClientWrapper, id, isPersistentId, Paths.get("api/access/"));
+        super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/access/"));
         log.trace("ENTER");
     }
+
+    protected DataAccessRequestsApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId) {
+        super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/access/"));
+        log.trace("ENTER");
+    }
+
 
     public DataverseResponse<DataMessage> enable() throws IOException, DataverseException {
         log.trace("ENTER");

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
@@ -56,6 +56,7 @@ public class DataAccessRequestsApi extends AbstractTargetedApi {
 
 
     private DataverseResponse<DataMessage> toggle(String bool) throws IOException, DataverseException {
+        headers.putAll(extraHeaders);
         return httpClientWrapper.putTextString(subPath, bool, params, headers, DataMessage.class);
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -58,16 +58,13 @@ import static java.util.Collections.singletonMap;
 public class DatasetApi extends AbstractTargetedApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
-    private final Map<String, String> extraHeaders = new HashMap<>();
 
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         this(httpClientWrapper, id, isPersistentId, null);
     }
 
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId) {
-        super(httpClientWrapper, id, isPersistentId, Paths.get("api/datasets/"));
-        if (invocationId != null)
-            extraHeaders.put("X-Dataverse-invocationID", invocationId);
+        super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/datasets/"));
     }
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
@@ -68,7 +68,7 @@ public class DataverseClient {
     public void checkConnection() throws IOException, DataverseException {
         logger.info("Checking if root dataverse can be reached...");
         dataverse("root").view().getData();
-            logger.info("OK: root dataverse is reachable.");
+        logger.info("OK: root dataverse is reachable.");
     }
 
     public WorkflowsApi workflows() {
@@ -107,6 +107,10 @@ public class DataverseClient {
         return new FileApi(httpClientWrapper, String.valueOf(id), false);
     }
 
+    public FileApi file(int id, String invocationId) {
+        return new FileApi(httpClientWrapper, String.valueOf(id), false, invocationId);
+    }
+
     public DataAccessRequestsApi accessRequests(String pid) {
         return new DataAccessRequestsApi(httpClientWrapper, pid, true);
     }
@@ -115,12 +119,28 @@ public class DataverseClient {
         return new DataAccessRequestsApi(httpClientWrapper, String.valueOf(id), false);
     }
 
+    public DataAccessRequestsApi accessRequests(String pid, String invocationId) {
+        return new DataAccessRequestsApi(httpClientWrapper, pid, true, invocationId);
+    }
+
+    public DataAccessRequestsApi accessRequests(int id, String invocationId) {
+        return new DataAccessRequestsApi(httpClientWrapper, String.valueOf(id), false, invocationId);
+    }
+
     public BasicFileAccessApi basicFileAccess(String pid) {
         return new BasicFileAccessApi(httpClientWrapper, pid, true);
     }
 
+    public BasicFileAccessApi basicFileAccess(String pid, String invocationId) {
+        return new BasicFileAccessApi(httpClientWrapper, pid, true, invocationId);
+    }
+
     public BasicFileAccessApi basicFileAccess(int id) {
         return new BasicFileAccessApi(httpClientWrapper, Integer.toString(id), false);
+    }
+
+    public BasicFileAccessApi basicFileAccess(int id, String invocationId) {
+        return new BasicFileAccessApi(httpClientWrapper, Integer.toString(id), false, invocationId);
     }
 
     public SearchApi search() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
@@ -39,7 +39,11 @@ public class FileApi extends AbstractTargetedApi {
     private static final Logger logger = LoggerFactory.getLogger(DatasetApi.class);
 
     protected FileApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
-        super(httpClientWrapper, id, isPersistentId, Paths.get("api/v1/files/"));
+        super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/v1/files/"));
+    }
+
+    protected FileApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId) {
+        super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/v1/files/"));
     }
 
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#restrict-files
@@ -51,7 +55,7 @@ public class FileApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#adding-file-metadata
 
     /**
-     * @param optDataFile the data file
+     * @param optDataFile     the data file
      * @param optFileMetadata json containing file metadata
      * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse


### PR DESCRIPTION
Fixes DD-1061

# Description of changes
The workflow step `invocationId` can now be passed in all targeted APIs.

# How to test
To test this you need to use the API from a workflow step that has received an `invocationId`, for example the virus scan. 

# Related PRs 
* https://github.com/DANS-KNAW/dd-workflow-step-virus-scan/pull/4

# Notify
@DANS-KNAW/dataversedans
