### PR TITLE
DD-1131 Metadata character encoding problems on test_ssh migration

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -124,7 +124,7 @@ class HttpClientWrapper implements MediaTypes {
         HttpPost post = new HttpPost(buildURi(subPath, parameters));
         post.setHeader(HttpHeaders.CONTENT_TYPE, mediaType);
         headers.forEach(post::setHeader);
-        post.setEntity(new StringEntity(s));
+        post.setEntity(new StringEntity(s, StandardCharsets.UTF_8));
         return dispatch(post);
     }
 
@@ -160,7 +160,7 @@ class HttpClientWrapper implements MediaTypes {
         HttpPut put = new HttpPut(buildURi(subPath, parameters));
         put.setHeader(HttpHeaders.CONTENT_TYPE, mediaType);
         headers.forEach(put::setHeader);
-        put.setEntity(new StringEntity(s));
+        put.setEntity(new StringEntity(s, StandardCharsets.UTF_8));
         return dispatch(put);
     }
 


### PR DESCRIPTION
Fixes DD-1131

# Description of changes
* Use UTF-8 as char encoding explicitly when sending strings.


# How to test
* Send a non-ascii string.


# Notify
@DANS-KNAW/dataversedans
