### PR TITLE
NO JIRA. Use Lombok for shorter class definitions

### DIFF
--- a/add-javadocs.sh
+++ b/add-javadocs.sh
@@ -19,12 +19,15 @@ set -e
 
 echo "START add javadocs..."
 pushd lib
+echo "Delomboking first, so that getters and setters will appear in JavaDocs"
+mvn clean lombok:delombok
+echo "Calling JavaDoc"
 mvn javadoc:javadoc
 popd
-
+echo "Removing existing JavaDocs if present"
 if [ -d "docs/javadocs" ]; then rm -fr docs/javadocs; fi
+echo "Moving newly generated JavaDocs in place"
 mv lib/target/site/apidocs docs/javadocs
-
 echo "DONE build and add javadocs"
 
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminGetDatabaseSetting.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminGetDatabaseSetting.java
@@ -21,8 +21,6 @@ import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 public class AdminGetDatabaseSetting extends ExampleBase {
 
     private static final Logger log = LoggerFactory.getLogger(AdminGetDatabaseSetting.class);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
@@ -24,7 +24,7 @@ public class DatasetAwaitLock extends ExampleBase {
     private static final Logger log = LoggerFactory.getLogger(DatasetAwaitLock.class);
 
     /**
-     * The easiest way to test this manually is to create an InReview lock. Other locks will be released to quickly.
+     * The easiest way to test this manually is to create an InReview lock. Other locks will be released too quickly.
      *
      * 1. Create a dataset.
      * 2. Start the program.

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
@@ -23,7 +23,7 @@ public class DatasetAwaitUnlock extends ExampleBase {
     private static final Logger log = LoggerFactory.getLogger(DatasetAwaitUnlock.class);
 
     /**
-     * The easiest way to test this manually is to create an InReview lock. Other locks will be released to quickly.
+     * The easiest way to test this manually is to create an InReview lock. Other locks will be released too quickly.
      *
      * 1. Create a dataset.
      * 2. Submit the dataset for review.

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
@@ -15,11 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.FieldList;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
-import nl.knaw.dans.lib.dataverse.DataverseResponse;
-import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
@@ -41,5 +41,6 @@ public class DatasetGetVersion extends ExampleBase {
         log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
         log.info("Create Time: {}", r.getData().getCreateTime());
         log.info("Version State: {}", r.getData().getVersionState());
+        log.info("Version UNF: {}", r.getData().getUnf());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
@@ -17,13 +17,10 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DatasetApi;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
-import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
 
 public class DatasetGetVersion extends ExampleBase {
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
@@ -16,9 +16,9 @@
 package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseContact;
-import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseIsMetadataBlocksRoot.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseIsMetadataBlocksRoot.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
-import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoleAssignments.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoleAssignments.java
@@ -17,8 +17,6 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
-import nl.knaw.dans.lib.dataverse.model.Role;
-import nl.knaw.dans.lib.dataverse.model.RoleAssignment;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignmentReadOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
-import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.Role;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
-import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseView.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseView.java
@@ -16,8 +16,8 @@
 package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
-import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -104,6 +104,24 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration combine.children="override">
+                    <sourcepath>target/delombok</sourcepath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>1.18.20.0</version>
+                <configuration>
+                    <sourceDirectory>src/main/java</sourceDirectory>
+                    <outputDirectory>target/delombok</outputDirectory>
+                    <verbose>true</verbose>
+                    <formatPreferences>
+                        <generateDelombokComment>skip</generateDelombokComment>
+                        <javaLangAsFQN>skip</javaLangAsFQN>
+                        <suppressWarnings>skip</suppressWarnings>
+                    </formatPreferences>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
@@ -16,10 +16,10 @@
 package nl.knaw.dans.lib.dataverse;
 
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundMultiValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.ControlledSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
-import nl.knaw.dans.lib.dataverse.model.dataset.CompoundSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.SingleValueField;
 
 import java.util.HashMap;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.Role;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignment;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseException.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseException.java
@@ -15,22 +15,17 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
-import lombok.Data;
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.http.HttpResponse;
 
-@ToString
+@Getter
 public class DataverseException extends Exception {
-    @Getter
     private final int status;
-    @Getter
     private final HttpResponse httpResponse;
 
     public DataverseException(int status, String msg, HttpResponse httpResponse) {
-        super(msg);
+        super(String.format("status: %d; message: %s", status, msg));
         this.status = status;
         this.httpResponse = httpResponse;
     }
-
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseException.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseException.java
@@ -15,10 +15,16 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
 import org.apache.http.HttpResponse;
 
+@ToString
 public class DataverseException extends Exception {
+    @Getter
     private final int status;
+    @Getter
     private final HttpResponse httpResponse;
 
     public DataverseException(int status, String msg, HttpResponse httpResponse) {
@@ -27,19 +33,4 @@ public class DataverseException extends Exception {
         this.httpResponse = httpResponse;
     }
 
-    public int getStatus() {
-        return status;
-    }
-
-    public HttpResponse getHttpResponse() {
-        return httpResponse;
-    }
-
-    @Override
-    public String toString() {
-        return "DataverseException{" +
-            "status=" + status +
-            ", httpResponse=" + httpResponse +
-            '}';
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
@@ -67,7 +67,6 @@ public class MetadataFieldDeserializer extends StdDeserializer {
             }
             else {
                 return new PrimitiveSingleValueField(
-                    typeClass,
                     typeName,
                     valueNode.asText());
             }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataMessage.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataMessage.java
@@ -15,14 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Data;
+
+@Data
 public class DataMessage {
     private String message;
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelope.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelope.java
@@ -15,33 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
-public class DataverseEnvelope<D> {
+import lombok.Data;
 
+@Data
+public class DataverseEnvelope<D> {
     private String status;
     private DataMessage message;
     private D data;
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    public DataMessage getMessage() {
-        return message;
-    }
-
-    public void setMessage(DataMessage message) {
-        this.message = message;
-    }
-
-    public D getData() {
-        return data;
-    }
-
-    public void setData(D data) {
-        this.data = data;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/ExportedDatasetVersionName.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/ExportedDatasetVersionName.java
@@ -21,9 +21,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility class to parse the names of dataset versions exported to RDA bags and metadata files. This is useful if you use `LocalSubmitToArchiveCommand` [to export the bags to a local
- * disk](https://guides.dataverse.org/en/latest/installation/config.html#local-path-configuration).
+ * Utility class to parse the names of dataset versions exported to RDA bags and metadata files. This is useful if you use <code>LocalSubmitToArchiveCommand</code> <a
+ * href="https://guides.dataverse.org/en/latest/installation/config.html#local-path-configuration" target="_blank">to export the bags to a local disk</a>.
  */
+@Getter
 public class ExportedDatasetVersionName {
     /*
      Reverse-engineered from edu.harvard.iq.dataverse.engine.command.impl.LocalSubmitToArchiveCommand, the pattern that the local filename should adhere to is:
@@ -36,20 +37,15 @@ public class ExportedDatasetVersionName {
     private static final String EXTENSION_PATTERN = "(?<extension>.zip|.xml)";
     private static final Pattern PATTERN = Pattern.compile(SPACENAME_PATTERN + SCHEMA_PATTERN + DATASET_VERSION_PATTERN + EXTENSION_PATTERN);
 
-    @Getter
     /**
      * The part of the filename derived from the global ID (doi, handle)
      *
      * @return the spacename
      */
     private final String spaceName;
-    @Getter
     private final String schema;
-    @Getter
     private final int majorVersion;
-    @Getter
     private final int minorVersion;
-    @Getter
     private final String extension;
 
     /**

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/ExportedDatasetVersionName.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/ExportedDatasetVersionName.java
@@ -15,12 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Getter;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility class to parse the names of dataset versions exported to RDA bags and metadata files. This is useful if you use `LocalSubmitToArchiveCommand`
- * [to export the bags to a local disk](https://guides.dataverse.org/en/latest/installation/config.html#local-path-configuration).
+ * Utility class to parse the names of dataset versions exported to RDA bags and metadata files. This is useful if you use `LocalSubmitToArchiveCommand` [to export the bags to a local
+ * disk](https://guides.dataverse.org/en/latest/installation/config.html#local-path-configuration).
  */
 public class ExportedDatasetVersionName {
     /*
@@ -34,10 +36,20 @@ public class ExportedDatasetVersionName {
     private static final String EXTENSION_PATTERN = "(?<extension>.zip|.xml)";
     private static final Pattern PATTERN = Pattern.compile(SPACENAME_PATTERN + SCHEMA_PATTERN + DATASET_VERSION_PATTERN + EXTENSION_PATTERN);
 
+    @Getter
+    /**
+     * The part of the filename derived from the global ID (doi, handle)
+     *
+     * @return the spacename
+     */
     private final String spaceName;
+    @Getter
     private final String schema;
+    @Getter
     private final int majorVersion;
+    @Getter
     private final int minorVersion;
+    @Getter
     private final String extension;
 
     /**
@@ -54,30 +66,5 @@ public class ExportedDatasetVersionName {
         majorVersion = Integer.parseInt(matcher.group("major"));
         minorVersion = Integer.parseInt(matcher.group("minor"));
         extension = matcher.group("extension");
-    }
-
-    /**
-     * The part of the filename derived from the global ID (doi, handle)
-     *
-     * @return the spacename
-     */
-    public String getSpaceName() {
-        return spaceName;
-    }
-
-    public String getSchema() {
-        return schema;
-    }
-
-    public int getMajorVersion() {
-        return majorVersion;
-    }
-
-    public int getMinorVersion() {
-        return minorVersion;
-    }
-
-    public String getExtension() {
-        return extension;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Lock.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Lock.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.lib.dataverse.model;
 
 import lombok.Data;
-import lombok.ToString;
 
 @Data
 public class Lock {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Lock.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Lock.java
@@ -15,62 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Data;
+import lombok.ToString;
+
+@Data
 public class Lock {
     private String lockType;
     private String date;
     private String user;
     private String dataset;
     private String message;
-
-    @Override
-    public String toString() {
-        return "Lock{" +
-            "lockType='" + lockType + '\'' +
-            ", date='" + date + '\'' +
-            ", user='" + user + '\'' +
-            ", dataset='" + dataset + '\'' +
-            ", message='" + message + '\'' +
-            '}';
-    }
-
-    public String getLockType() {
-        return lockType;
-    }
-
-    public void setLockType(String lockType) {
-        this.lockType = lockType;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
-    }
-
-    public String getUser() {
-        return user;
-    }
-
-    public void setUser(String user) {
-        this.user = user;
-    }
-
-    public String getDataset() {
-        return dataset;
-    }
-
-    public void setDataset(String dataset) {
-        this.dataset = dataset;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Role.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/Role.java
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class Role {
     private int id;
     private int ownerId;
@@ -24,52 +27,4 @@ public class Role {
     private String name;
     private String description;
     private List<String> permissions;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getOwnerId() {
-        return ownerId;
-    }
-
-    public void setOwnerId(int ownerId) {
-        this.ownerId = ownerId;
-    }
-
-    public String getAlias() {
-        return alias;
-    }
-
-    public void setAlias(String alias) {
-        this.alias = alias;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public List<String> getPermissions() {
-        return permissions;
-    }
-
-    public void setPermissions(List<String> permissions) {
-        this.permissions = permissions;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/RoleAssignment.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/RoleAssignment.java
@@ -15,23 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Data;
+
+@Data
 public class RoleAssignment {
     private String assignee;
     private String role;
-
-    public String getAssignee() {
-        return assignee;
-    }
-
-    public void setAssignee(String assignee) {
-        this.assignee = assignee;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/RoleAssignmentReadOnly.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/RoleAssignmentReadOnly.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
+import lombok.Data;
+
+@Data
 public class RoleAssignmentReadOnly {
     private int id;
     private String assignee;
@@ -22,52 +25,4 @@ public class RoleAssignmentReadOnly {
     private String _roleAlias;
     private String definitionPointId;
     private String privateUrlToken;
-
-    public String getAssignee() {
-        return assignee;
-    }
-
-    public void setAssignee(String assignee) {
-        this.assignee = assignee;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getRoleId() {
-        return roleId;
-    }
-
-    public void setRoleId(int roleId) {
-        this.roleId = roleId;
-    }
-
-    public String get_roleAlias() {
-        return _roleAlias;
-    }
-
-    public void set_roleAlias(String _roleAlias) {
-        this._roleAlias = _roleAlias;
-    }
-
-    public String getDefinitionPointId() {
-        return definitionPointId;
-    }
-
-    public void setDefinitionPointId(String definitionPointId) {
-        this.definitionPointId = definitionPointId;
-    }
-
-    public String getPrivateUrlToken() {
-        return privateUrlToken;
-    }
-
-    public void setPrivateUrlToken(String privateUrlToken) {
-        this.privateUrlToken = privateUrlToken;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundMultiValueField.java
@@ -15,26 +15,24 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.List;
 import java.util.Map;
 
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class CompoundMultiValueField extends MetadataField {
 
     private List<Map<String, SingleValueField>> value;
 
-    public CompoundMultiValueField() {
-    }
-
     public CompoundMultiValueField(String typeName, List<Map<String, SingleValueField>> value) {
         super("compound", typeName, true);
-        this.value = value;
-    }
-
-    public List<Map<String, SingleValueField>> getValue() {
-        return value;
-    }
-
-    public void setValue(List<Map<String, SingleValueField>> value) {
         this.value = value;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundMultiValueField.java
@@ -15,17 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.List;
 import java.util.Map;
 
-@NoArgsConstructor
-@Getter
-@Setter
+
+@Data
 @EqualsAndHashCode(callSuper = true)
 public class CompoundMultiValueField extends MetadataField {
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundSingleValueField.java
@@ -15,16 +15,12 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.Map;
 
-@NoArgsConstructor
-@Getter
-@Setter
+@Data
 @EqualsAndHashCode(callSuper = true)
 public class CompoundSingleValueField extends MetadataField {
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/CompoundSingleValueField.java
@@ -15,26 +15,23 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.Map;
 
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class CompoundSingleValueField extends MetadataField {
 
     private Map<String, SingleValueField> value;
-
-    public CompoundSingleValueField() {
-    }
 
     public CompoundSingleValueField(String typeName, Map<String, SingleValueField> value) {
         super("compound", typeName, false);
         this.value = value;
     }
-
-    public Map<String, SingleValueField> getValue() {
-        return value;
-    }
-
-    public void setValue(Map<String, SingleValueField> value) {
-        this.value = value;
-    }
-
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
@@ -15,24 +15,22 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.List;
 
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class ControlledMultiValueField extends MetadataField {
     private List<String> value;
 
-    public ControlledMultiValueField() {
-    }
-
     public ControlledMultiValueField(String typeName, List<String> value) {
         super("controlledVocabulary", typeName, true);
-        this.value = value;
-    }
-
-    public List<String> getValue() {
-        return value;
-    }
-
-    public void setValue(List<String> value) {
         this.value = value;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledMultiValueField.java
@@ -15,16 +15,12 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.List;
 
-@NoArgsConstructor
-@Getter
-@Setter
+@Data
 @EqualsAndHashCode(callSuper = true)
 public class ControlledMultiValueField extends MetadataField {
     private List<String> value;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
@@ -15,14 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@NoArgsConstructor
-@Getter
-@Setter
+@Data
 @EqualsAndHashCode(callSuper = true)
 public class ControlledSingleValueField extends MetadataField implements SingleValueField {
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueField.java
@@ -15,23 +15,21 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
-public class ControlledSingleValueField extends MetadataField implements SingleValueField{
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+public class ControlledSingleValueField extends MetadataField implements SingleValueField {
 
     private String value;
 
-    public ControlledSingleValueField() {
-    }
-
     public ControlledSingleValueField(String typeName, String value) {
         super("controlledVocabulary", typeName, false);
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
         this.value = value;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Dataset.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Dataset.java
@@ -15,23 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
+@Data
 public class Dataset {
     private DatasetVersion datasetVersion;
     private DatasetVersion latestVersion;
-
-    public DatasetVersion getDatasetVersion() {
-        return datasetVersion;
-    }
-
-    public void setDatasetVersion(DatasetVersion datasetVersion) {
-        this.datasetVersion = datasetVersion;
-    }
-
-    public DatasetVersion getLatestVersion() {
-        return latestVersion;
-    }
-
-    public void setLatestVersion(DatasetVersion latestVersion) {
-        this.latestVersion = latestVersion;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetCreationResult.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetCreationResult.java
@@ -15,23 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
+@Data
 public class DatasetCreationResult {
     private int id;
     private String persistentId;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getPersistentId() {
-        return persistentId;
-    }
-
-    public void setPersistentId(String persistentId) {
-        this.persistentId = persistentId;
-    }
 }
+

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetPublicationResult.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetPublicationResult.java
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
 import java.net.URI;
 
+@Data
 public class DatasetPublicationResult {
     private int id;
     private String identifier;
@@ -27,76 +30,4 @@ public class DatasetPublicationResult {
     private String publicationDate;
     private String storageIdentifier;
     private String metadataLanguage;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public URI getPersistentUrl() {
-        return persistentUrl;
-    }
-
-    public void setPersistentUrl(URI persistentUrl) {
-        this.persistentUrl = persistentUrl;
-    }
-
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-
-    public String getAuthority() {
-        return authority;
-    }
-
-    public void setAuthority(String authority) {
-        this.authority = authority;
-    }
-
-    public String getPublisher() {
-        return publisher;
-    }
-
-    public void setPublisher(String publisher) {
-        this.publisher = publisher;
-    }
-
-    public String getPublicationDate() {
-        return publicationDate;
-    }
-
-    public void setPublicationDate(String publicationDate) {
-        this.publicationDate = publicationDate;
-    }
-
-    public String getStorageIdentifier() {
-        return storageIdentifier;
-    }
-
-    public void setStorageIdentifier(String storageIdentifier) {
-        this.storageIdentifier = storageIdentifier;
-    }
-
-    public String getMetadataLanguage() {
-        return metadataLanguage;
-    }
-
-    public void setMetadataLanguage(String metadataLanguage) {
-        this.metadataLanguage = metadataLanguage;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
@@ -16,11 +16,13 @@
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 
 import java.util.List;
 import java.util.Map;
 
+@Data
 public class DatasetVersion {
 
     private Integer id;
@@ -29,17 +31,24 @@ public class DatasetVersion {
     private String storageIdentifier;
     private Integer versionNumber;
     private Integer versionMinorNumber;
-    private String versionState; // TODO: to enum
-    private String versionNote; // TODO: to enum
+    private String versionState;
+    private String versionNote;
+    @JsonProperty("UNF")
     private String unf;
-    private String lastUpdateTime; // TODO: timestamp?
-    private String releaseTime; // TODO: timestamp?
-    private String createTime; // TODO: timestamp?
-    private String distributionDate; // TODO: timestamp?
-    private String productionDate; // TODO: timestamp?
+    private String lastUpdateTime;
+    private String releaseTime;
+    private String createTime;
+    private String distributionDate;
+    private String productionDate;
     private Boolean fileAccessRequest;
     private String termsOfUse;
     private String termsOfAccess;
+    private String dataAccessPlace;
+    private String originalArchive;
+    private String availabilityStatus;
+    private String contactForAccess;
+    private String sizeOfCollection;
+    private String studyCompletion;
     private License license;
     private String protocol;
     private String authority;
@@ -47,198 +56,4 @@ public class DatasetVersion {
     private Map<String, MetadataBlock> metadataBlocks;
     private List<FileMeta> files;
     private String citation;
-
-    public Integer getId() {
-        return id;
-    }
-
-    public void setId(Integer id) {
-        this.id = id;
-    }
-
-    public Integer getDatasetId() {
-        return datasetId;
-    }
-
-    public void setDatasetId(Integer datasetId) {
-        this.datasetId = datasetId;
-    }
-
-    public String getDatasetPersistentId() {
-        return datasetPersistentId;
-    }
-
-    public void setDatasetPersistentId(String datasetPersistentId) {
-        this.datasetPersistentId = datasetPersistentId;
-    }
-
-    public String getStorageIdentifier() {
-        return storageIdentifier;
-    }
-
-    public void setStorageIdentifier(String storageIdentifier) {
-        this.storageIdentifier = storageIdentifier;
-    }
-
-    public Integer getVersionNumber() {
-        return versionNumber;
-    }
-
-    public void setVersionNumber(Integer versionNumber) {
-        this.versionNumber = versionNumber;
-    }
-
-    public Integer getVersionMinorNumber() {
-        return versionMinorNumber;
-    }
-
-    public void setVersionMinorNumber(Integer versionMinorNumber) {
-        this.versionMinorNumber = versionMinorNumber;
-    }
-
-    public String getVersionState() {
-        return versionState;
-    }
-
-    public void setVersionState(String versionState) {
-        this.versionState = versionState;
-    }
-
-    public String getVersionNote() {
-        return versionNote;
-    }
-
-    public void setVersionNote(String versionNote) {
-        this.versionNote = versionNote;
-    }
-
-    @JsonProperty("UNF")
-    public String getUNF() {
-        return unf;
-    }
-
-    @JsonProperty("UNF")
-    public void setUNF(String unf) {
-        this.unf = unf;
-    }
-
-    public String getLastUpdateTime() {
-        return lastUpdateTime;
-    }
-
-    public void setLastUpdateTime(String lastUpdateTime) {
-        this.lastUpdateTime = lastUpdateTime;
-    }
-
-    public String getReleaseTime() {
-        return releaseTime;
-    }
-
-    public void setReleaseTime(String releaseTime) {
-        this.releaseTime = releaseTime;
-    }
-
-    public String getCreateTime() {
-        return createTime;
-    }
-
-    public void setCreateTime(String createTime) {
-        this.createTime = createTime;
-    }
-
-    public String getDistributionDate() {
-        return distributionDate;
-    }
-
-    public void setDistributionDate(String distributionDate) {
-        this.distributionDate = distributionDate;
-    }
-
-    public String getProductionDate() {
-        return productionDate;
-    }
-
-    public void setProductionDate(String productionDate) {
-        this.productionDate = productionDate;
-    }
-
-    public Boolean isFileAccessRequest() {
-        return fileAccessRequest;
-    }
-
-    public void setFileAccessRequest(Boolean fileAccessRequest) {
-        this.fileAccessRequest = fileAccessRequest;
-    }
-
-    public String getTermsOfUse() {
-        return termsOfUse;
-    }
-
-    public void setTermsOfUse(String termsOfUse) {
-        this.termsOfUse = termsOfUse;
-    }
-
-    public String getTermsOfAccess() {
-        return termsOfAccess;
-    }
-
-    public void setTermsOfAccess(String termsOfAccess) {
-        this.termsOfAccess = termsOfAccess;
-    }
-
-    public License getLicense() {
-        return license;
-    }
-
-    public void setLicense(License license) {
-        this.license = license;
-    }
-
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-
-    public String getAuthority() {
-        return authority;
-    }
-
-    public void setAuthority(String authority) {
-        this.authority = authority;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public Map<String, MetadataBlock> getMetadataBlocks() {
-        return metadataBlocks;
-    }
-
-    public void setMetadataBlocks(Map<String, MetadataBlock> metadataBlocks) {
-        this.metadataBlocks = metadataBlocks;
-    }
-
-    public List<FileMeta> getFiles() {
-        return files;
-    }
-
-    public void setFiles(List<FileMeta> files) {
-        this.files = files;
-    }
-
-    public String getCitation() {
-        return citation;
-    }
-
-    public void setCitation(String citation) {
-        this.citation = citation;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
@@ -15,38 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class Embargo {
     private String dateAvailable;
     private String reason;
     private int[] fileIds;
-
-    public Embargo(String dateAvailable, String reason, int[] fileIds) {
-        this.dateAvailable = dateAvailable;
-        this.reason = reason;
-        this.fileIds = fileIds;
-    }
-
-    public String getDateAvailable() {
-        return dateAvailable;
-    }
-
-    public void setDateAvailable(String dateAvailable) {
-        this.dateAvailable = dateAvailable;
-    }
-
-    public String getReason() {
-        return reason;
-    }
-
-    public void setReason(String reason) {
-        this.reason = reason;
-    }
-
-    public int[] getFileIds() {
-        return fileIds;
-    }
-
-    public void setFileIds(int[] fileIds) {
-        this.fileIds = fileIds;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FieldList.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FieldList.java
@@ -15,19 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@Data
 public class FieldList {
     private List<MetadataField> fields = new ArrayList<>();
-
-    public List<MetadataField> getFields() {
-        return fields;
-    }
-
-    public void setFields(List<MetadataField> fields) {
-        this.fields = fields;
-    }
 
     public void add(MetadataField field) {
         fields.add(field);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FileList.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/FileList.java
@@ -15,25 +15,16 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 
 import java.util.List;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class FileList {
     private List<FileMeta> files;
-
-    public FileList() {
-    }
-
-    public FileList(List<FileMeta> files) {
-        this.files = files;
-    }
-
-    public List<FileMeta> getFiles() {
-        return files;
-    }
-
-    public void setFiles(List<FileMeta> files) {
-        this.files = files;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/License.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/License.java
@@ -15,25 +15,16 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.net.URI;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class License {
     private String name;
     private URI uri;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public URI getUri() {
-        return uri;
-    }
-
-    public void setUri(URI uri) {
-        this.uri = uri;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlock.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlock.java
@@ -15,35 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class MetadataBlock {
 
     private String displayName;
     private String name;
     private List<MetadataField> fields;
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public List<MetadataField> getFields() {
-        return fields;
-    }
-
-    public void setFields(List<MetadataField> fields) {
-        this.fields = fields;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlockSummary.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataBlockSummary.java
@@ -15,32 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+
+@Data
 public class MetadataBlockSummary {
     int id;
     String name;
     String displayName;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/MetadataField.java
@@ -15,42 +15,16 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public abstract class MetadataField {
 
     private String typeClass;
     private String typeName;
     private boolean multiple;
-
-    public MetadataField() {
-    }
-
-    public MetadataField(String typeClass, String typeName, boolean multiple) {
-        this.typeClass = typeClass;
-        this.typeName = typeName;
-        this.multiple = multiple;
-    }
-
-    public String getTypeClass() {
-        return typeClass;
-    }
-
-    public void setTypeClass(String typeClass) {
-        this.typeClass = typeClass;
-    }
-
-    public String getTypeName() {
-        return typeName;
-    }
-
-    public void setTypeName(String typeName) {
-        this.typeName = typeName;
-    }
-
-    public boolean isMultiple() {
-        return multiple;
-    }
-
-    public void setMultiple(boolean multiple) {
-        this.multiple = multiple;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
@@ -15,24 +15,21 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.List;
 
+@NoArgsConstructor
 public class PrimitiveMultiValueField extends MetadataField {
-    private List<String> value;
 
-    public PrimitiveMultiValueField() {
-    }
+    @Getter
+    @Setter
+    private List<String> value;
 
     public PrimitiveMultiValueField(String typeName, List<String> value) {
         super("primitive", typeName, true);
-        this.value = value;
-    }
-
-    public List<String> getValue() {
-        return value;
-    }
-
-    public void setValue(List<String> value) {
         this.value = value;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
@@ -15,16 +15,12 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.List;
 
-@NoArgsConstructor
-@Getter
-@Setter
+@Data
 @EqualsAndHashCode(callSuper = true)
 public class PrimitiveMultiValueField extends MetadataField {
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveMultiValueField.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,10 +23,11 @@ import lombok.Setter;
 import java.util.List;
 
 @NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class PrimitiveMultiValueField extends MetadataField {
 
-    @Getter
-    @Setter
     private List<String> value;
 
     public PrimitiveMultiValueField(String typeName, List<String> value) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
@@ -15,28 +15,19 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
 public class PrimitiveSingleValueField extends MetadataField implements SingleValueField {
 
+    @Getter
+    @Setter
     private String value;
-
-    public PrimitiveSingleValueField() {
-    }
 
     public PrimitiveSingleValueField(String typeName, String value) {
         super("primitive", typeName, false);
-        this.value = value;
-    }
-
-    public PrimitiveSingleValueField(String typeClass, String typeName, String value) {
-        super(typeClass, typeName, false);
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
         this.value = value;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
@@ -17,16 +17,9 @@ package nl.knaw.dans.lib.dataverse.model.dataset;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-//@NoArgsConstructor
-//@Getter
-//@Setter
-//@EqualsAndHashCode(callSuper = true)
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class PrimitiveSingleValueField extends MetadataField implements SingleValueField {
 
     private String value;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/PrimitiveSingleValueField.java
@@ -15,15 +15,20 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
+//@NoArgsConstructor
+//@Getter
+//@Setter
+//@EqualsAndHashCode(callSuper = true)
+
+@Data
 public class PrimitiveSingleValueField extends MetadataField implements SingleValueField {
 
-    @Getter
-    @Setter
     private String value;
 
     public PrimitiveSingleValueField(String typeName, String value) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/Dataverse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/Dataverse.java
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class Dataverse {
     private int id;
     private int ownerId;
@@ -30,100 +33,4 @@ public class Dataverse {
     private String creationDate;
     private DataverseTheme theme;
     private List<DataverseContact> dataverseContacts;
-
-    public DataverseTheme getTheme() {
-        return theme;
-    }
-
-    public void setTheme(DataverseTheme theme) {
-        this.theme = theme;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getOwnerId() {
-        return ownerId;
-    }
-
-    public void setOwnerId(int ownerId) {
-        this.ownerId = ownerId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getAlias() {
-        return alias;
-    }
-
-    public void setAlias(String alias) {
-        this.alias = alias;
-    }
-
-    public boolean isPermissionRoot() {
-        return permissionRoot;
-    }
-
-    public void setPermissionRoot(boolean permissionRoot) {
-        this.permissionRoot = permissionRoot;
-    }
-
-    public String getAffiliation() {
-        return affiliation;
-    }
-
-    public void setAffiliation(String affiliation) {
-        this.affiliation = affiliation;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public DataverseType getDataverseType() {
-        return dataverseType;
-    }
-
-    public void setDataverseType(DataverseType dataverseType) {
-        this.dataverseType = dataverseType;
-    }
-
-    public String getStorageDriverLabel() {
-        return storageDriverLabel;
-    }
-
-    public void setStorageDriverLabel(String storageDriverLabel) {
-        this.storageDriverLabel = storageDriverLabel;
-    }
-
-    public String getCreationDate() {
-        return creationDate;
-    }
-
-    public void setCreationDate(String creationDate) {
-        this.creationDate = creationDate;
-    }
-
-    public List<DataverseContact> getDataverseContacts() {
-        return dataverseContacts;
-    }
-
-    public void setDataverseContacts(List<DataverseContact> dataverseContacts) {
-        this.dataverseContacts = dataverseContacts;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseContact.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseContact.java
@@ -15,31 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class DataverseContact {
     private int displayOrder;
     private String contactEmail;
-
-    public DataverseContact() {
-    }
-
-    public DataverseContact(int displayOrder, String contactEmail) {
-        this.displayOrder = displayOrder;
-        this.contactEmail = contactEmail;
-    }
-
-    public int getDisplayOrder() {
-        return displayOrder;
-    }
-
-    public void setDisplayOrder(int displayOrder) {
-        this.displayOrder = displayOrder;
-    }
-
-    public String getContactEmail() {
-        return contactEmail;
-    }
-
-    public void setContactEmail(String contactEmail) {
-        this.contactEmail = contactEmail;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseDatasetItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseDatasetItem.java
@@ -16,10 +16,12 @@
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.net.URI;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class DataverseDatasetItem extends DataverseItem {
     private String identifier;
     private URI persistentUrl;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseDatasetItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseDatasetItem.java
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.Data;
+
 import java.net.URI;
 
+@Data
 public class DataverseDatasetItem extends DataverseItem {
     private String identifier;
     private URI persistentUrl;
@@ -29,69 +32,5 @@ public class DataverseDatasetItem extends DataverseItem {
 
     public DataverseDatasetItem() {
         super(DataverseItemType.dataset);
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public URI getPersistentUrl() {
-        return persistentUrl;
-    }
-
-    public void setPersistentUrl(URI persistentUrl) {
-        this.persistentUrl = persistentUrl;
-    }
-
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-
-    public String getAuthority() {
-        return authority;
-    }
-
-    public void setAuthority(String authority) {
-        this.authority = authority;
-    }
-
-    public String getPublisher() {
-        return publisher;
-    }
-
-    public void setPublisher(String publisher) {
-        this.publisher = publisher;
-    }
-
-    public String getPublicationDate() {
-        return publicationDate;
-    }
-
-    public void setPublicationDate(String publicationDate) {
-        this.publicationDate = publicationDate;
-    }
-
-    public String getStorageIdentifier() {
-        return storageIdentifier;
-    }
-
-    public void setStorageIdentifier(String storageIdentifier) {
-        this.storageIdentifier = storageIdentifier;
-    }
-
-    public String getMetadataLanguage() {
-        return metadataLanguage;
-    }
-
-    public void setMetadataLanguage(String metadataLanguage) {
-        this.metadataLanguage = metadataLanguage;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseItem.java
@@ -15,31 +15,17 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public abstract class DataverseItem {
     private DataverseItemType type;
     private int id;
-
-    public DataverseItem() {
-    }
-
     public DataverseItem(DataverseItemType type) {
         this.type = type;
-    }
-
-    public DataverseItem(DataverseItemType type, int id) {
-        this.type = type;
-        this.id = id;
-    }
-
-    public DataverseItemType getType() {
-        return type;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseSubverseItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseSubverseItem.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.Data;
+
+@Data
 public class DataverseSubverseItem extends DataverseItem {
     private String title;
 
@@ -24,14 +27,6 @@ public class DataverseSubverseItem extends DataverseItem {
 
     public DataverseSubverseItem(String title, int id) {
         super(DataverseItemType.dataverse, id);
-        this.title = title;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
         this.title = title;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseSubverseItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseSubverseItem.java
@@ -16,8 +16,10 @@
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class DataverseSubverseItem extends DataverseItem {
     private String title;
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseTheme.java
@@ -15,62 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataverse;
 
+import lombok.Data;
+
+@Data
 public class DataverseTheme {
     private int id;
     private String logo;
     private String logoBackgroundColor;
-
     private String tagline;
-
     private String linkColor;
-
     private String textColor;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getLogo() {
-        return logo;
-    }
-
-    public void setLogo(String logo) {
-        this.logo = logo;
-    }
-
-    public String getLogoBackgroundColor() {
-        return logoBackgroundColor;
-    }
-
-    public void setLogoBackgroundColor(String logoBackgroundColor) {
-        this.logoBackgroundColor = logoBackgroundColor;
-    }
-
-    public String getTagline() {
-        return tagline;
-    }
-
-    public void setTagline(String tagline) {
-        this.tagline = tagline;
-    }
-
-    public String getLinkColor() {
-        return linkColor;
-    }
-
-    public void setLinkColor(String linkColor) {
-        this.linkColor = linkColor;
-    }
-
-    public String getTextColor() {
-        return textColor;
-    }
-
-    public void setTextColor(String textColor) {
-        this.textColor = textColor;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
@@ -15,24 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.file;
 
+import lombok.Data;
+
+@Data
 public class Checksum {
 
   private String type;
   private String Value;
-
-  public String getValue() {
-    return Value;
-  }
-
-  public void setValue(String value) {
-    Value = value;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
@@ -15,9 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse.model.file;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Checksum {
 
   private String type;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
@@ -17,7 +17,9 @@ package nl.knaw.dans.lib.dataverse.model.file;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 @JsonIgnoreProperties({ "md5" }) // The optional "md5" property is redundant and only there for backward compatibility. 
 public class DataFile {
   private int   id;
@@ -33,155 +35,10 @@ public class DataFile {
   private String originalFormatLabel;
   private Long originalFileSize;
   private String originalFileName;
+  @JsonProperty("UNF")
   private String unf;
   private int rootDataFileId;
   private Checksum checksum;
-  private String creationDate; // TODO why not a DateTime?
+  private String creationDate;
   private int previousDataFileId;
-
-  public int getPreviousDataFileId() {
-    return previousDataFileId;
-  }
-
-  public void setPreviousDataFileId(int previousDataFileId) {
-    this.previousDataFileId = previousDataFileId;
-  }
-
-  public String getCreationDate() {
-    return creationDate;
-  }
-
-  public void setCreationDate(String creationDate) {
-    this.creationDate = creationDate;
-  }
-
-  public Checksum getChecksum() {
-    return checksum;
-  }
-
-  public void setChecksum(Checksum checksum) {
-    this.checksum = checksum;
-  }
-
-  public Embargo getEmbargo() {
-    return embargo;
-  }
-
-  public void setEmbargo(Embargo embargo) {
-    this.embargo = embargo;
-  }
-
-  public int getRootDataFileId() {
-    return rootDataFileId;
-  }
-
-  public void setRootDataFileId(int rootDataFileId) {
-    this.rootDataFileId = rootDataFileId;
-  }
-
-  public String getStorageIdentifier() {
-    return storageIdentifier;
-  }
-
-  public void setStorageIdentifier(String storageIdentifier) {
-    this.storageIdentifier = storageIdentifier;
-  }
-
-  public long getFilesize() {
-    return filesize;
-  }
-
-  public void setFilesize(long filesize) {
-    this.filesize = filesize;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getContentType() {
-    return contentType;
-  }
-
-  public void setContentType(String contentType) {
-    this.contentType = contentType;
-  }
-
-  public String getFilename() {
-    return filename;
-  }
-
-  public void setFilename(String filename) {
-    this.filename = filename;
-  }
-
-  public String getPidURL() {
-    return pidURL;
-  }
-
-  public void setPidURL(String pidURL) {
-    this.pidURL = pidURL;
-  }
-
-  public String getPersistentId() {
-    return persistentId;
-  }
-
-  public void setPersistentId(String persistentId) {
-    this.persistentId = persistentId;
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
-  }
-
-  @JsonProperty("UNF")
-  public String getUnf() {
-    return unf;
-  }
-
-  @JsonProperty("UNF")
-  public void setUnf(String unf) {
-    this.unf = unf;
-  }
-
-  public String getOriginalFileName() {
-    return originalFileName;
-  }
-
-  public void setOriginalFileName(String originalFileName) {
-    this.originalFileName = originalFileName;
-  }
-
-  public Long getOriginalFileSize() {
-    return originalFileSize;
-  }
-
-  public void setOriginalFileSize(Long originalFileSize) {
-    this.originalFileSize = originalFileSize;
-  }
-
-  public String getOriginalFormatLabel() {
-    return originalFormatLabel;
-  }
-
-  public void setOriginalFormatLabel(String originalFormatLabel) {
-    this.originalFormatLabel = originalFormatLabel;
-  }
-
-  public String getOriginalFileFormat() {
-    return originalFileFormat;
-  }
-
-  public void setOriginalFileFormat(String originalFileFormat) {
-    this.originalFileFormat = originalFileFormat;
-  }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Embargo.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Embargo.java
@@ -15,24 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.model.file;
 
+import lombok.Data;
+
+@Data
 public class Embargo {
-
-  private String dateAvailable;
-  private String reason;
-
-  public String getDateAvailable() {
-    return dateAvailable;
-  }
-
-  public void setDateAvailable(String dateAvailable) {
-    this.dateAvailable = dateAvailable;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
+    private String dateAvailable;
+    private String reason;
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
@@ -15,11 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse.model.file;
 
+import lombok.Data;
 import nl.knaw.dans.lib.dataverse.model.file.prestaged.Checksum;
 import nl.knaw.dans.lib.dataverse.model.file.prestaged.PrestagedFile;
 
 import java.util.List;
 
+@Data
 public class FileMeta {
 
     private String label;
@@ -28,12 +30,9 @@ public class FileMeta {
     private int version;
     private int datasetVersionId;
     private Boolean restricted;
-    private List<String> categories; // TODO Enum or vocab? https://guides.dataverse.org/en/latest/user/dataset-management.html?highlight=category#file-tags
+    private List<String> categories;
     private DataFile dataFile;
     private Boolean forceReplace;
-
-    public FileMeta() {
-    }
 
     public PrestagedFile toPrestagedFile() {
         if (dataFile == null)
@@ -49,30 +48,6 @@ public class FileMeta {
         p.setRestrict(restricted);
         p.setForceReplace(forceReplace);
         return p;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public void setLabel(String label) {
-        this.label = label;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getDirectoryLabel() {
-        return directoryLabel;
-    }
-
-    public void setDirectoryLabel(String directoryLabel) {
-        this.directoryLabel = directoryLabel;
     }
 
     /**
@@ -114,46 +89,5 @@ public class FileMeta {
     public void setRestricted(Boolean restricted) {
         this.restricted = restricted;
     }
-
-    public List<String> getCategories() {
-        return categories;
-    }
-
-    public void setCategories(List<String> categories) {
-        this.categories = categories;
-    }
-
-    public Boolean getForceReplace() {
-        return forceReplace;
-    }
-
-    public void setForceReplace(Boolean forceReplace) {
-        this.forceReplace = forceReplace;
-    }
-
-    public DataFile getDataFile() {
-        return dataFile;
-    }
-
-    public void setDataFile(DataFile dataFile) {
-        this.dataFile = dataFile;
-    }
-
-    public int getDatasetVersionId() {
-        return datasetVersionId;
-    }
-
-    public void setDatasetVersionId(int datasetVersionId) {
-        this.datasetVersionId = datasetVersionId;
-    }
-
-    public int getVersion() {
-        return version;
-    }
-
-    public void setVersion(int version) {
-        this.version = version;
-    }
-
 }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
@@ -90,7 +90,7 @@ public class FileMeta {
     /**
      * See comments in the {@link #getRestrict()} method docs.
      *
-     * @return whether the file is or should be restricted
+     * @param restrict whether to restrict the file or not
      */
     public void setRestrict(Boolean restrict) {
         this.restricted = restrict;
@@ -109,7 +109,7 @@ public class FileMeta {
     /**
      * See comments in the {@link #getRestrict()} method docs.
      *
-     * @return whether the file is or should be restricted
+     * @param restricted whether to restrict the file or not
      */
     public void setRestricted(Boolean restricted) {
         this.restricted = restricted;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/prestaged/Checksum.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/prestaged/Checksum.java
@@ -16,36 +16,16 @@
 package nl.knaw.dans.lib.dataverse.model.file.prestaged;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Checksum {
+    @JsonProperty("@type")
     private String type;
+    @JsonProperty("@value")
     private String value;
-
-    public Checksum() {
-    }
-
-    public Checksum(String type, String value) {
-        this.type = type;
-        this.value = value;
-    }
-
-    @JsonProperty("@type")
-    public String getType() {
-        return type;
-    }
-
-    @JsonProperty("@type")
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    @JsonProperty("@value")
-    public String getValue() {
-        return value;
-    }
-
-    @JsonProperty("@value")
-    public void setValue(String value) {
-        this.value = value;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/prestaged/PrestagedFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/prestaged/PrestagedFile.java
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.file.prestaged;
 
+import lombok.Data;
+
 import java.util.List;
 
+@Data
 public class PrestagedFile {
     private String storageIdentifier;
     private String fileName;
@@ -27,76 +30,4 @@ public class PrestagedFile {
     private List<String> categories;
     private Boolean restrict;
     private Boolean forceReplace;
-
-    public String getStorageIdentifier() {
-        return storageIdentifier;
-    }
-
-    public void setStorageIdentifier(String storageIdentifier) {
-        this.storageIdentifier = storageIdentifier;
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-
-    public String getMimeType() {
-        return mimeType;
-    }
-
-    public void setMimeType(String mimeType) {
-        this.mimeType = mimeType;
-    }
-
-    public Checksum getChecksum() {
-        return checksum;
-    }
-
-    public void setChecksum(Checksum checksum) {
-        this.checksum = checksum;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getDirectoryLabel() {
-        return directoryLabel;
-    }
-
-    public void setDirectoryLabel(String directoryLabel) {
-        this.directoryLabel = directoryLabel;
-    }
-
-    public List<String> getCategories() {
-        return categories;
-    }
-
-    public void setCategories(List<String> categories) {
-        this.categories = categories;
-    }
-
-    public Boolean getRestrict() {
-        return restrict;
-    }
-
-    public void setRestrict(Boolean restrict) {
-        this.restrict = restrict;
-    }
-
-    public Boolean getForceReplace() {
-        return forceReplace;
-    }
-
-    public void setForceReplace(Boolean forceReplace) {
-        this.forceReplace = forceReplace;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/Contact.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/Contact.java
@@ -15,31 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.model.search;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Contact {
     private String name;
     private String affiliation;
-
-    public Contact() {
-    }
-
-    public Contact(String name, String affiliation) {
-        this.name = name;
-        this.affiliation = affiliation;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getAffiliation() {
-        return affiliation;
-    }
-
-    public void setAffiliation(String affiliation) {
-        this.affiliation = affiliation;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DatasetResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DatasetResultItem.java
@@ -17,11 +17,13 @@ package nl.knaw.dans.lib.dataverse.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 import java.util.Map;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class DatasetResultItem extends ResultItem {
 
     @JsonProperty("global_id")

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DatasetResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DatasetResultItem.java
@@ -16,16 +16,21 @@
 package nl.knaw.dans.lib.dataverse.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
 import java.util.List;
 import java.util.Map;
 
+@Data
 public class DatasetResultItem extends ResultItem {
 
+    @JsonProperty("global_id")
     private String globalId;
     private String publisher;
     private String citationHtml;
+    @JsonProperty("identifier_of_dataverse")
     private String identifierOfDataverse;
+    @JsonProperty("name_of_dataverse")
     private String nameOfDataverse;
     private String citation;
     private String storageIdentifier;
@@ -35,163 +40,13 @@ public class DatasetResultItem extends ResultItem {
     private String versionState;
     private Integer majorVersion;
     private Integer minorVersion;
-    private String createdAt; // TODO: use timestamp class
-    private String updatedAt; // TODO: use timestamp class
+    private String createdAt;
+    private String updatedAt;
     private List<Contact> contacts;
     private List<String> authors;
-    private List<Map<Object, Object>> publications; // TODO: this field seems to appear when there exists a draft version.
+    private List<Map<Object, Object>> publications;
 
     public DatasetResultItem() {
         super(SearchItemType.dataset);
-    }
-
-    @JsonProperty("global_id")
-    public String getGlobalId() {
-        return globalId;
-    }
-
-    @JsonProperty("global_id")
-    public void setGlobalId(String globalId) {
-        this.globalId = globalId;
-    }
-
-    public String getPublisher() {
-        return publisher;
-    }
-
-    public void setPublisher(String publisher) {
-        this.publisher = publisher;
-    }
-
-    public String getCitationHtml() {
-        return citationHtml;
-    }
-
-    public void setCitationHtml(String citationHtml) {
-        this.citationHtml = citationHtml;
-    }
-
-    @JsonProperty("identifier_of_dataverse")
-    public String getIdentifierOfDataverse() {
-        return identifierOfDataverse;
-    }
-
-    @JsonProperty("identifier_of_dataverse")
-    public void setIdentifierOfDataverse(String identifierOfDataverse) {
-        this.identifierOfDataverse = identifierOfDataverse;
-    }
-
-    @JsonProperty("name_of_dataverse")
-    public String getNameOfDataverse() {
-        return nameOfDataverse;
-    }
-
-    @JsonProperty("name_of_dataverse")
-    public void setNameOfDataverse(String nameOfDataverse) {
-        this.nameOfDataverse = nameOfDataverse;
-    }
-
-    public String getCitation() {
-        return citation;
-    }
-
-    public void setCitation(String citation) {
-        this.citation = citation;
-    }
-
-    public String getStorageIdentifier() {
-        return storageIdentifier;
-    }
-
-    public void setStorageIdentifier(String storageIdentifier) {
-        this.storageIdentifier = storageIdentifier;
-    }
-
-    public List<String> getSubjects() {
-        return subjects;
-    }
-
-    public void setSubjects(List<String> subjects) {
-        this.subjects = subjects;
-    }
-
-    public Integer getFileCount() {
-        return fileCount;
-    }
-
-    public void setFileCount(Integer fileCount) {
-        this.fileCount = fileCount;
-    }
-
-    public Integer getVersionId() {
-        return versionId;
-    }
-
-    public void setVersionId(Integer versionId) {
-        this.versionId = versionId;
-    }
-
-    public String getVersionState() {
-        return versionState;
-    }
-
-    public void setVersionState(String versionState) {
-        this.versionState = versionState;
-    }
-
-    public Integer getMajorVersion() {
-        return majorVersion;
-    }
-
-    public void setMajorVersion(Integer majorVersion) {
-        this.majorVersion = majorVersion;
-    }
-
-    public Integer getMinorVersion() {
-        return minorVersion;
-    }
-
-    public void setMinorVersion(Integer minorVersion) {
-        this.minorVersion = minorVersion;
-    }
-
-    public String getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(String createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public String getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(String updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public List<Contact> getContacts() {
-        return contacts;
-    }
-
-    public void setContacts(List<Contact> contacts) {
-        this.contacts = contacts;
-    }
-
-    public List<String> getAuthors() {
-        return authors;
-    }
-
-    public void setAuthors(List<String> authors) {
-        this.authors = authors;
-    }
-
-    public List<Map<Object, Object>> getPublications() {
-        return publications;
-    }
-
-    public void setPublications(List<Map<Object, Object>> publications) {
-        this.publications = publications;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DataverseResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DataverseResultItem.java
@@ -15,12 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse.model.search;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.net.URI;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class DataverseResultItem extends ResultItem {
     private String identifier;
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DataverseResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/DataverseResultItem.java
@@ -15,8 +15,12 @@
  */
 package nl.knaw.dans.lib.dataverse.model.search;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
 import java.net.URI;
 
+@Data
 public class DataverseResultItem extends ResultItem {
     private String identifier;
 
@@ -32,13 +36,4 @@ public class DataverseResultItem extends ResultItem {
         setPublishedAt(publishedAt);
         this.identifier = identifier;
     }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/FileResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/FileResultItem.java
@@ -15,8 +15,10 @@
  */
 package nl.knaw.dans.lib.dataverse.model.search;
 
+import lombok.Data;
 import nl.knaw.dans.lib.dataverse.model.file.Checksum;
 
+@Data
 public class FileResultItem extends ResultItem {
     private String fileType;
     private String fileContentType;
@@ -29,70 +31,6 @@ public class FileResultItem extends ResultItem {
 
     public FileResultItem() {
         super(SearchItemType.file);
-    }
-
-    public String getFileType() {
-        return fileType;
-    }
-
-    public void setFileType(String fileType) {
-        this.fileType = fileType;
-    }
-
-    public String getFileContentType() {
-        return fileContentType;
-    }
-
-    public void setFileContentType(String fileContentType) {
-        this.fileContentType = fileContentType;
-    }
-
-    public Long getSizeInBytes() {
-        return sizeInBytes;
-    }
-
-    public void setSizeInBytes(Long sizeInBytes) {
-        this.sizeInBytes = sizeInBytes;
-    }
-
-    public Checksum getChecksum() {
-        return checksum;
-    }
-
-    public void setChecksum(Checksum checksum) {
-        this.checksum = checksum;
-    }
-
-    public String getDatasetName() {
-        return datasetName;
-    }
-
-    public void setDatasetName(String datasetName) {
-        this.datasetName = datasetName;
-    }
-
-    public String getDatasetId() {
-        return datasetId;
-    }
-
-    public void setDatasetId(String datasetId) {
-        this.datasetId = datasetId;
-    }
-
-    public String getDatasetPersistentId() {
-        return datasetPersistentId;
-    }
-
-    public void setDatasetPersistentId(String datasetPersistentId) {
-        this.datasetPersistentId = datasetPersistentId;
-    }
-
-    public String getDatasetCitation() {
-        return datasetCitation;
-    }
-
-    public void setDatasetCitation(String datasetCitation) {
-        this.datasetCitation = datasetCitation;
     }
 }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/FileResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/FileResultItem.java
@@ -16,9 +16,11 @@
 package nl.knaw.dans.lib.dataverse.model.search;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import nl.knaw.dans.lib.dataverse.model.file.Checksum;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class FileResultItem extends ResultItem {
     private String fileType;
     private String fileContentType;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
@@ -27,49 +27,14 @@ public abstract class ResultItem {
     private String name;
     private URI url;
     private String description;
-    private String publishedAt; // TODO: to date format
+    @JsonProperty("published_at")
+    private String publishedAt;
+
     protected ResultItem() {
         this.type = SearchItemType.dataset;
     }
+
     protected ResultItem(SearchItemType type) {
         this.type = type;
-    }
-
-    public SearchItemType getType() {
-        return type;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public URI getUrl() {
-        return url;
-    }
-
-    public void setUrl(URI url) {
-        this.url = url;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @JsonProperty("published_at")
-    public String getPublishedAt() {
-        return publishedAt;
-    }
-
-    @JsonProperty("published_at")
-    public void setPublishedAt(String publishedAt) {
-        this.publishedAt = publishedAt;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.lib.dataverse.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.net.URI;
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/ResultItem.java
@@ -16,17 +16,22 @@
 package nl.knaw.dans.lib.dataverse.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.net.URI;
 
 // Mix between snake_case and camelCase, so we need to specify per field what name conversion strategy to use for (de)serialization
+@Data
 public abstract class ResultItem {
     private final SearchItemType type;
     private String name;
     private URI url;
     private String description;
     private String publishedAt; // TODO: to date format
-
+    protected ResultItem() {
+        this.type = SearchItemType.dataset;
+    }
     protected ResultItem(SearchItemType type) {
         this.type = type;
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/SearchResult.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/search/SearchResult.java
@@ -17,11 +17,17 @@ package nl.knaw.dans.lib.dataverse.model.search;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class SearchResult {
     private String q;
     private int totalCount;
@@ -29,64 +35,4 @@ public class SearchResult {
     private Map<String, String> spellingAlternatives;
     private List<ResultItem> items;
     private int countInResponse;
-
-    public SearchResult() {
-    }
-
-    public SearchResult(String q, int totalCount, int start, Map<String, String> spellingAlternatives, List<ResultItem> items, int countInResponse) {
-        this.q = q;
-        this.totalCount = totalCount;
-        this.start = start;
-        this.spellingAlternatives = spellingAlternatives;
-        this.items = items;
-        this.countInResponse = countInResponse;
-    }
-
-    public String getQ() {
-        return q;
-    }
-
-    public void setQ(String q) {
-        this.q = q;
-    }
-
-    public int getTotalCount() {
-        return totalCount;
-    }
-
-    public void setTotalCount(int totalCount) {
-        this.totalCount = totalCount;
-    }
-
-    public int getStart() {
-        return start;
-    }
-
-    public void setStart(int start) {
-        this.start = start;
-    }
-
-    public Map<String, String> getSpellingAlternatives() {
-        return spellingAlternatives;
-    }
-
-    public void setSpellingAlternatives(Map<String, String> spellingAlternatives) {
-        this.spellingAlternatives = spellingAlternatives;
-    }
-
-    public List<ResultItem> getItems() {
-        return items;
-    }
-
-    public void setItems(List<ResultItem> items) {
-        this.items = items;
-    }
-
-    public int getCountInResponse() {
-        return countInResponse;
-    }
-
-    public void setCountInResponse(int countInResponse) {
-        this.countInResponse = countInResponse;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/user/AuthenticatedUser.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/user/AuthenticatedUser.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model.user;
 
+import lombok.Data;
+
+@Data
 public class AuthenticatedUser {
     private int id;
     private String identifier;
@@ -31,134 +34,5 @@ public class AuthenticatedUser {
     private String lastLoginTime;
     private String lastApiUseTime;
     private String authenticationProviderId;
-
     private String emailLastConfirmed;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public boolean isSuperuser() {
-        return superuser;
-    }
-
-    public boolean isDeactivated() {
-        return deactivated;
-    }
-
-    public void setDeactivated(boolean deactivated) {
-        this.deactivated = deactivated;
-    }
-
-    public void setSuperuser(boolean superuser) {
-        this.superuser = superuser;
-    }
-
-    public String getAffiliation() {
-        return affiliation;
-    }
-
-    public void setAffiliation(String affiliation) {
-        this.affiliation = affiliation;
-    }
-
-    public String getPosition() {
-        return position;
-    }
-
-    public void setPosition(String position) {
-        this.position = position;
-    }
-
-    public String getPersistentUserId() {
-        return persistentUserId;
-    }
-
-    public void setPersistentUserId(String persistentUserId) {
-        this.persistentUserId = persistentUserId;
-    }
-
-    public String getCreatedTime() {
-        return createdTime;
-    }
-
-    public void setCreatedTime(String createdTime) {
-        this.createdTime = createdTime;
-    }
-
-    public String getLastLoginTime() {
-        return lastLoginTime;
-    }
-
-    public void setLastLoginTime(String lastLoginTime) {
-        this.lastLoginTime = lastLoginTime;
-    }
-
-    public String getLastApiUseTime() {
-        return lastApiUseTime;
-    }
-
-    public void setLastApiUseTime(String lastApiUseTime) {
-        this.lastApiUseTime = lastApiUseTime;
-    }
-
-    public String getAuthenticationProviderId() {
-        return authenticationProviderId;
-    }
-
-    public void setAuthenticationProviderId(String authenticationProviderId) {
-        this.authenticationProviderId = authenticationProviderId;
-    }
-
-    public String getEmailLastConfirmed() {
-        return emailLastConfirmed;
-    }
-
-    public void setEmailLastConfirmed(String emailLastConfirmed) {
-        this.emailLastConfirmed = emailLastConfirmed;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/user/BuiltinUser.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/user/BuiltinUser.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model.user;
 
+import lombok.Data;
+
+@Data
 public class BuiltinUser {
     private String firstName;
     private String lastName;
@@ -22,52 +25,4 @@ public class BuiltinUser {
     private String affiliation;
     private String position;
     private String email;
-
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getUserName() {
-        return userName;
-    }
-
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    public String getAffiliation() {
-        return affiliation;
-    }
-
-    public void setAffiliation(String affiliation) {
-        this.affiliation = affiliation;
-    }
-
-    public String getPosition() {
-        return position;
-    }
-
-    public void setPosition(String position) {
-        this.position = position;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/workflow/ResumeMessage.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/workflow/ResumeMessage.java
@@ -16,46 +16,16 @@
 package nl.knaw.dans.lib.dataverse.model.workflow;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
+@Data
+@AllArgsConstructor
 public class ResumeMessage {
-
+    @JsonProperty("Status")
     private String status;
+    @JsonProperty("Reason")
     private String reason;
+    @JsonProperty("Message")
     private String message;
-
-    public ResumeMessage(@JsonProperty("Status") String status, @JsonProperty("Reason") String reason, @JsonProperty("Message") String message) {
-        this.status = status;
-        this.reason = reason;
-        this.message = message;
-    }
-
-    @JsonProperty("Status")
-    public String getStatus() {
-        return status;
-    }
-
-    @JsonProperty("Status")
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    @JsonProperty("Reason")
-    public String getReason() {
-        return reason;
-    }
-
-    @JsonProperty("Reason")
-    public void setReason(String reason) {
-        this.reason = reason;
-    }
-
-    @JsonProperty("Message")
-    public String getMessage() {
-        return message;
-    }
-
-    @JsonProperty("Message")
-    public void setMessage(String message) {
-        this.message = message;
-    }
 }


### PR DESCRIPTION
NO JIRA

# Description of changes
* Introduced [Lombok](https://projectlombok.org/features/), as it successfully used before in `dd-ingest-flow` by @ericdevries .
* Modified `./add-javaocs.sh` to first delombok the code, so that the methods generated by Lombok are shown in the JavaDocs. Otherwise you would not be able to see what properties each bean has.
* Most bean classes are now annotated with `@Data`. In a lot of cases they maybe further simplified to values with `@Value`, but I will first see how this change works out before doing another iteration.

# Notify

@DANS-KNAW/dataversedans
