### PR TITLE
DD-1313: Allow passing system metadata keys to editMetadata

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,8 +17,13 @@ because it does not need any input and simply returns the `view` of the root ver
 
 In the following example program arguments the `$DOI` is a placeholder for a DOI of the Dataset that is being manipulated; lie `doi:10.5072/FK2/ABCD`. 
 
+## Examples that mutate the dataset metadata
 
-## DatasetUpdateMetadataFromJsonLd
+These potentially need a system metadata key to work. 
+If you don't provide the right key you get an error message: 
+"Updating system metadata in block citation requires a valid key". 
+
+### DatasetUpdateMetadataFromJsonLd
 
 Updates the metadata of a dataset using the JSON-LD format. 
 
@@ -42,7 +47,7 @@ or back to default
 For the license change no system metadata key is needed. 
 
 
-## DatasetUpdateMetadata
+### DatasetUpdateMetadata
 
 This sets all values in code, the only thing you need to provide is a DOI.
 When you have set up Dataverse to protect the citation metadata block with a secret key you need provide this also.
@@ -50,16 +55,22 @@ When you have set up Dataverse to protect the citation metadata block with a sec
     $DOI citation mysecretkey
 
 
-## DatasetEditMetadata
+### DatasetEditMetadata
 
 Allows to change the `title` of the Dataset. Add the secret key if the citation block was protected. 
 
-        $DOI "My Edited Dataset" mysecretkey
+    $DOI "My Edited Dataset" mysecretkey
 
 
-## DataverseCreateDataset
+### DataverseCreateDataset
 
 Creates a new Dataset with metadata set in code. Add the secret key if the citation block was protected.
 
-        mysecretkey
+    mysecretkey
 
+### DataverseImportDataset
+
+Imports a Dataset with metadata set in code. The DOI is automatically generated in the test code. 
+Add the secret key if the citation block was protected.
+
+    mysecretkey

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,3 +4,62 @@ Examples
 This project contains sample code  that shows how to use the library. The examples
 are part of the same GitHub repository and can be found in the [examples sub-module](https://github.com/DANS-KNAW/dans-dataverse-client-lib/tree/master/examples/){:target=_blank:}.
 
+# Running the examples
+
+Copy the supplied `dataverse.properties.template` to `dataverse.properties` 
+and edit the properties to match your setup. 
+For example; when running the `dev_dataversenl` VM, set the `baseUrl=http://ddvnl.dans.knaw.nl:8080`. 
+Note the `http` and `8080` to circumvent any SSL and self signed certificate problems. 
+Also make sure you have the correct API key and unblock secret. 
+
+The simples example just to check that you can connect is running the `DataverseView.java`, 
+because it does not need any input and simply returns the `view` of the root verse. 
+
+In the following example program arguments the `$DOI` is a placeholder for a DOI of the Dataset that is being manipulated; lie `doi:10.5072/FK2/ABCD`. 
+
+
+## DatasetUpdateMetadataFromJsonLd
+
+Updates the metadata of a dataset using the JSON-LD format. 
+
+To change the title
+
+    $DOI http://purl.org/dc/terms/title "Some new title"
+
+When you have set up Dataverse to protect a metadata block with a secret key you can provide ths also. 
+For the `citation` metadata block (where the `title` is) and the key `mysecretkey`:
+
+    $DOI http://purl.org/dc/terms/title "Some new title" citation mysecretkey
+
+You can also update the license (not part of a metadata block) with the following arguments:
+ 
+    $DOI http://schema.org/license  http://creativecommons.org/licenses/by-nc/4.0
+
+or back to default 
+
+    $DOI http://creativecommons.org/publicdomain/zero/1.0
+
+For the license change no system metadata key is needed. 
+
+
+## DatasetUpdateMetadata
+
+This sets all values in code, the only thing you need to provide is a DOI.
+When you have set up Dataverse to protect the citation metadata block with a secret key you need provide this also.
+
+    $DOI citation mysecretkey
+
+
+## DatasetEditMetadata
+
+Allows to change the `title` of the Dataset. Add the secret key if the citation block was protected. 
+
+        $DOI "My Edited Dataset" citation mysecretkey
+
+
+## DataverseCreateDataset
+
+Creates a new Dataset with metadata set in code. Add the secret key if the citation block was protected.
+
+        citation mysecretkey
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -54,12 +54,12 @@ When you have set up Dataverse to protect the citation metadata block with a sec
 
 Allows to change the `title` of the Dataset. Add the secret key if the citation block was protected. 
 
-        $DOI "My Edited Dataset" citation mysecretkey
+        $DOI "My Edited Dataset" mysecretkey
 
 
 ## DataverseCreateDataset
 
 Creates a new Dataset with metadata set in code. Add the secret key if the citation block was protected.
 
-        citation mysecretkey
+        mysecretkey
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
@@ -23,6 +23,8 @@ import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+
 public class DatasetEditMetadata extends ExampleBase {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetEditMetadata.class);
@@ -30,9 +32,18 @@ public class DatasetEditMetadata extends ExampleBase {
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
         String title = args[1];
+
+        var keyMap = new HashMap<String, String>();
+        if (args.length > 3) {
+            var mdBlockName = args[2];
+            var mdKeyValue = args[3];
+            keyMap.put(mdBlockName, mdKeyValue);
+            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")" );
+        }
+
         FieldList fieldList = new FieldList();
         fieldList.add(new PrimitiveSingleValueField("title", title));
-        DataverseResponse<DatasetVersion> r = client.dataset(persistentId).editMetadata(fieldList);
+        DataverseResponse<DatasetVersion> r = client.dataset(persistentId).editMetadata(fieldList, keyMap);
         log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
         log.info("Version number: {}", r.getData().getVersionNumber());
     }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
@@ -34,11 +34,10 @@ public class DatasetEditMetadata extends ExampleBase {
         String title = args[1];
 
         var keyMap = new HashMap<String, String>();
-        if (args.length > 3) {
-            var mdBlockName = args[2];
-            var mdKeyValue = args[3];
-            keyMap.put(mdBlockName, mdKeyValue);
-            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")" );
+        if (args.length > 2) {
+            var mdKeyValue = args[2];
+            keyMap.put("citation", mdKeyValue);
+            System.out.println("Supplied citation metadata key: " + mdKeyValue );
         }
 
         FieldList fieldList = new FieldList();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 
 public class DatasetUpdateMetadata extends ExampleBase {
 
@@ -36,6 +37,13 @@ public class DatasetUpdateMetadata extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
+        var keyMap = new HashMap<String, String>();
+        if (args.length > 2) {
+            var mdBlockName = args[1];
+            var mdKeyValue = args[2];
+            keyMap.put(mdBlockName, mdKeyValue);
+            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")");
+        }
 
         MetadataBlock citation = new MetadataBlock();
         citation.setDisplayName("Citation Metadata");
@@ -66,7 +74,7 @@ public class DatasetUpdateMetadata extends ExampleBase {
             latest.setTermsOfAccess("Some new terms. Pray I don't alter them any further.");
             latest.setFiles(Collections.emptyList());
             latest.setMetadataBlocks(Collections.singletonMap("citation", citation));
-            var r2 = client.dataset(persistentId).updateMetadata(latest);
+            var r2 = client.dataset(persistentId).updateMetadata(latest, keyMap);
             log.info("Response message: {}", r2.getEnvelopeAsJson().toPrettyString());
             log.info("Version number: {}", r2.getData().getVersionNumber());
         } catch (DataverseException e) {

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
@@ -38,11 +38,10 @@ public class DatasetUpdateMetadata extends ExampleBase {
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
         var keyMap = new HashMap<String, String>();
-        if (args.length > 2) {
-            var mdBlockName = args[1];
-            var mdKeyValue = args[2];
-            keyMap.put(mdBlockName, mdKeyValue);
-            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")");
+        if (args.length > 1) {
+            var mdKeyValue = args[1];
+            keyMap.put("citation", mdKeyValue);
+            System.out.println("Supplied citation metadata key: " + mdKeyValue );
         }
 
         MetadataBlock citation = new MetadataBlock();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
@@ -38,19 +38,28 @@ public class DatasetUpdateMetadataFromJsonLd extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
-        URI licenseUri = new URI(args[1]);
-
-        var licenseObject = Map.of("http://schema.org/license", licenseUri);
-        var jsonLd = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(licenseObject);
+        var fieldName = args[1];
+        var fieldValue = args[2];
+        // Maybe default fieldName to http://schema.org/license ?
+        var fieldObject = Map.of(fieldName, fieldValue);
+        var jsonLd = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(fieldObject);
 
         log.info("--- BEGIN JSON OBJECT ---");
         System.out.println(jsonLd);
         log.info("--- END JSON OBJECT ---");
 
+        var keyMap = new HashMap<String, String>();
+        if (args.length > 4) {
+            var mdBlockName = args[3];
+            var mdKeyValue = args[4];
+            keyMap.put(mdBlockName, mdKeyValue);
+            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")" );
+        }
+
         try {
 
             DataverseResponse<Object> r = client.dataset(persistentId)
-                .updateMetadataFromJsonLd(jsonLd, true);
+                .updateMetadataFromJsonLd(jsonLd, true, keyMap);
             log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
         }
         catch (DataverseException e) {

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
@@ -39,11 +39,10 @@ public class DataverseCreateDataset extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         var keyMap = new HashMap<String, String>();
-        if (args.length > 1) {
-            var mdBlockName = args[0];
-            var mdKeyValue = args[1];
-            keyMap.put(mdBlockName, mdKeyValue);
-            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")" );
+        if (args.length > 0) {
+            var mdKeyValue = args[0];
+            keyMap.put("citation", mdKeyValue);
+            System.out.println("Supplied citation metadata key: " + mdKeyValue );
         }
 
         MetadataBlock citation = new MetadataBlock();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
@@ -32,11 +32,20 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 
 public class DataverseCreateDataset extends ExampleBase {
     private static final Logger log = LoggerFactory.getLogger(DataverseCreateDataset.class);
 
     public static void main(String[] args) throws Exception {
+        var keyMap = new HashMap<String, String>();
+        if (args.length > 1) {
+            var mdBlockName = args[0];
+            var mdKeyValue = args[1];
+            keyMap.put(mdBlockName, mdKeyValue);
+            System.out.println("Supplied metadata key (name, value): (" + mdBlockName + ", " + mdKeyValue + ")" );
+        }
+
         MetadataBlock citation = new MetadataBlock();
         citation.setName("citation");
         citation.setDisplayName("Citation Metadata");
@@ -73,7 +82,7 @@ public class DataverseCreateDataset extends ExampleBase {
         log.info(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(dataset));
         log.info("--- END JSON OBJECT ---");
 
-        DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").createDataset(dataset);
+        DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").createDataset(dataset, keyMap);
         log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
         log.info("DOI: {}", r.getData().getPersistentId());
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
@@ -1,0 +1,66 @@
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.dataset.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class DataverseImportDataset extends ExampleBase {
+    private static final Logger log = LoggerFactory.getLogger(DataverseImportDataset.class);
+
+    public static void main(String[] args) throws Exception {
+        var keyMap = new HashMap<String, String>();
+        if (args.length > 0) {
+            var mdKeyValue = args[0];
+            keyMap.put("citation", mdKeyValue);
+            System.out.println("Supplied citation metadata key: " + mdKeyValue );
+        }
+
+        MetadataBlock citation = new MetadataBlock();
+        citation.setName("citation");
+        citation.setDisplayName("Citation Metadata");
+
+        MetadataField title = new PrimitiveSingleValueField("title", "Test imported dataset");
+        MetadataField description = new CompoundFieldBuilder("dsDescription", true)
+                .addSubfield("dsDescriptionValue", "Test description")
+                .addSubfield("dsDescriptionDate", "").build();
+        MetadataField author = new CompoundFieldBuilder("author", true)
+                .addSubfield("authorName", "P E Loki")
+                .addSubfield("authorAffiliation", "Walhalla").build();
+        MetadataField contact = new CompoundFieldBuilder("datasetContact", true)
+                .addSubfield("datasetContactName", "Test Contact")
+                .addSubfield("datasetContactEmail", "test@example.com").build();
+        MetadataField subjects = new ControlledMultiValueField("subject", Arrays.asList("Arts and Humanities", "Computer and Information Science"));
+
+        citation.setFields(Arrays.asList(title, author, contact, description, subjects));
+
+        DatasetVersion version = new DatasetVersion();
+        version.setMetadataBlocks(Collections.singletonMap("citation", citation));
+        version.setFiles(Collections.emptyList()); // Otherwise a 400 Bad Request is returned; you are not allowed to change file metadata this way
+        // The license field is ignored, for how to set it, see example DatasetUpdateMetadataFromJsonLd
+        //        License license = new License();
+        //        license.setName("CC BY-NC-SA 4.0");
+        //        license.setUri(new URI("http://creativecommons.org/licenses/by-nc-sa/4.0"));
+        //        version.setLicense(license);
+        version.setTermsOfAccess("Some terms");
+        version.setFileAccessRequest(false);
+
+        Dataset dataset = new Dataset();
+        dataset.setDatasetVersion(version);
+
+        log.info("--- BEGIN JSON OBJECT ---");
+        log.info(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(dataset));
+        log.info("--- END JSON OBJECT ---");
+
+        UUID uuid = UUID.randomUUID();
+        Optional<String> optDoi = Optional.of("doi:10.5072/EDDA-RAGNAROK/IMPORTTEST-" + uuid.toString());
+        DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").importDataset(dataset, 
+                optDoi, false, keyMap);
+        log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
+    }
+
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -18,6 +18,10 @@ package nl.knaw.dans.lib.dataverse;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 abstract class AbstractApi {
 
@@ -35,5 +39,15 @@ abstract class AbstractApi {
             }
         }
         return p;
+    }
+
+    protected static final String MDKEY_PARAM_NAME_PREFIX = "mdkey.";
+
+    protected Map<String, List<String>> getQueryParamsFromMetadataKeys(Map<String, String> metadataKeys) {
+        return metadataKeys.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
+                        e -> Collections.singletonList(e.getValue())
+                ));
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -190,6 +190,18 @@ public class DatasetApi extends AbstractTargetedApi {
         return putToTarget("editMetadata", s, queryParams, DatasetVersion.class);
     }
 
+    public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
+        log.trace("ENTER");
+        HashMap<String, List<String>> queryParams = new HashMap<>(extraQueryParams);
+        if (replace)
+            /*
+             * Sic! any value for "replace" is interpreted by Dataverse as "true", even "replace=false"
+             * It is by the *absence* of the parameter that replace is set to false.
+             */
+            queryParams.put("replace", singletonList("true"));
+        return putToTarget("editMetadata", s, queryParams, DatasetVersion.class);
+    }
+
     /**
      * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
      * multiple values.
@@ -205,6 +217,10 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), replace);
     }
 
+    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
+        return editMetadata(httpClientWrapper.writeValueAsString(fields), replace, extraQueryParams);
+    }
+
     /**
      * Edits the current draft's metadata, adding the fields that do not exist yet.
      *
@@ -216,6 +232,10 @@ public class DatasetApi extends AbstractTargetedApi {
      */
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), true);
+    }
+
+    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
+        return editMetadata(httpClientWrapper.writeValueAsString(fields), true, extraQueryParams);
     }
 
     // TODO https://guides.dataverse.org/en/latest/api/native-api.html#export-metadata-of-a-dataset-in-various-formats

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -40,10 +40,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -57,7 +55,8 @@ import static java.util.Collections.singletonMap;
 public class DatasetApi extends AbstractTargetedApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
-
+    private static final String metadataKeyParamNamePrefix = "mdkey.";
+    
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         this(httpClientWrapper, id, isPersistentId, null);
     }
@@ -190,9 +189,13 @@ public class DatasetApi extends AbstractTargetedApi {
         return putToTarget("editMetadata", s, queryParams, DatasetVersion.class);
     }
 
-    public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
+    public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace, HashMap<String, String> metadataKeys) throws IOException, DataverseException {
         log.trace("ENTER");
-        HashMap<String, List<String>> queryParams = new HashMap<>(extraQueryParams);
+        HashMap<String, List<String>> queryParams = new HashMap<>(metadataKeys.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> metadataKeyParamNamePrefix + e.getKey(),
+                        e -> Collections.singletonList(e.getValue())
+                )));
         if (replace)
             /*
              * Sic! any value for "replace" is interpreted by Dataverse as "true", even "replace=false"
@@ -217,8 +220,8 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), replace);
     }
 
-    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
-        return editMetadata(httpClientWrapper.writeValueAsString(fields), replace, extraQueryParams);
+    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace, HashMap<String, String> metadataKeys) throws IOException, DataverseException {
+        return editMetadata(httpClientWrapper.writeValueAsString(fields), replace, metadataKeys);
     }
 
     /**
@@ -234,8 +237,8 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), true);
     }
 
-    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, HashMap<String, List<String>> extraQueryParams) throws IOException, DataverseException {
-        return editMetadata(httpClientWrapper.writeValueAsString(fields), true, extraQueryParams);
+    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, HashMap<String, String> metadataKeys) throws IOException, DataverseException {
+        return editMetadata(httpClientWrapper.writeValueAsString(fields), true, metadataKeys);
     }
 
     // TODO https://guides.dataverse.org/en/latest/api/native-api.html#export-metadata-of-a-dataset-in-various-formats

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -55,7 +55,6 @@ import static java.util.Collections.singletonMap;
 public class DatasetApi extends AbstractTargetedApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
-    private static final String MDKEY_PARAM_NAME_PREFIX = "mdkey.";
     
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         this(httpClientWrapper, id, isPersistentId, null);
@@ -164,6 +163,16 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(s, true, emptyMap());
     }
 
+    /**
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
+     *
+     * @param s            JSON document containing the edits to perform
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @return DatasetVersion
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetVersion> editMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
         return editMetadata(s, true, metadataKeys);
     }
@@ -190,7 +199,7 @@ public class DatasetApi extends AbstractTargetedApi {
      *
      * @param s       JSON document containing the edits to perform
      * @param replace whether to replace existing values
-     * @param metadataKeys  the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -222,6 +231,17 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(fields, replace, emptyMap());
     }
 
+    /**
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
+     *
+     * @param fields       list of fields to edit
+     * @param replace      whether to replace existing values
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @return DatasetVersion
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), replace, metadataKeys);
     }
@@ -239,6 +259,16 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(fields, true, emptyMap());
     }
 
+    /**
+     * Edits the current draft's metadata, adding the fields that do not exist yet.
+     *
+     * @param fields       list of fields to edit
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @return DatasetVersion
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetVersion> editMetadata(FieldList fields, Map<String, String> metadataKeys) throws IOException, DataverseException {
         return editMetadata(fields, true, metadataKeys);
     }
@@ -261,14 +291,10 @@ public class DatasetApi extends AbstractTargetedApi {
         return updateMetadataFromJsonLd(metadata, replace, emptyMap());
     }
 
-    public DataverseHttpResponse<Object> updateMetadataFromJsonLd(String metadata, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        return updateMetadataFromJsonLd(metadata,true, metadataKeys);
-    }
-
     /**
-     * @param metadata JSON document describing the metadata
-     * @param replace replace existing metadata
-     * @param metadataKeys  the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param metadata     JSON document describing the metadata
+     * @param replace      replace existing metadata
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
      * @return a generic DataverseResponse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -291,6 +317,14 @@ public class DatasetApi extends AbstractTargetedApi {
         return updateMetadata(s, emptyMap());
     }
 
+    /**
+     * @param s JSON document containing the new metadata
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @return DatasetVersion
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetVersion> updateMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
         Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         // Cheating with endPoint here, because the only version that can be updated is :draft anyway
@@ -309,9 +343,17 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetVersion> updateMetadata(DatasetVersion version) throws IOException, DataverseException {
-        return updateMetadata(version, emptyMap());
+        return updateMetadata(httpClientWrapper.writeValueAsString(version), emptyMap());
     }
 
+    /**
+     * @param version a version object containing the new metadata
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @return DatasetVersion
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetVersion> updateMetadata(DatasetVersion version, Map<String, String> metadataKeys) throws IOException, DataverseException {
         return updateMetadata(httpClientWrapper.writeValueAsString(version), metadataKeys);
     }
@@ -611,11 +653,4 @@ public class DatasetApi extends AbstractTargetedApi {
             throw new RuntimeException(String.format("%s. Number of tries = %d, wait time between tries = %d ms.", errorMessage, maxNumberOfRetries, waitTimeInMilliseconds));
     }
     
-    private Map<String, List<String>> getQueryParamsFromMetadataKeys(Map<String, String> metadataKeys) {
-         return metadataKeys.entrySet().stream()
-                .collect(Collectors.toMap(
-                        e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
-                        e -> Collections.singletonList(e.getValue())
-                ));
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -163,7 +163,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(String s) throws IOException, DataverseException {
-        return editMetadata(s, true);
+        return editMetadata(s, true, emptyMap());
     }
 
     public DataverseResponse<DatasetVersion> editMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
@@ -201,7 +201,7 @@ public class DatasetApi extends AbstractTargetedApi {
      */
     public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
         log.trace("ENTER");
-        HashMap<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
+        Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         if (replace)
             /*
              * Sic! any value for "replace" is interpreted by Dataverse as "true", even "replace=false"
@@ -279,7 +279,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        HashMap<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
+        Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         queryParams.put("replace", singletonList((String.valueOf(replace))));
         return httpClientWrapper.putJsonLdString(subPath("metadata"), metadata, params(queryParams), extraHeaders, RoleAssignmentReadOnly.class);
     }
@@ -296,7 +296,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     public DataverseResponse<DatasetVersion> updateMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        HashMap<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
+        Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         // Cheating with endPoint here, because the only version that can be updated is :draft anyway
         return putToTarget("versions/:draft", s, queryParams, DatasetVersion.class);
     }
@@ -616,11 +616,11 @@ public class DatasetApi extends AbstractTargetedApi {
             throw new RuntimeException(String.format("%s. Number of tries = %d, wait time between tries = %d ms.", errorMessage, maxNumberOfRetries, waitTimeInMilliseconds));
     }
     
-    private HashMap<String, List<String>> getQueryParamsFromMetadataKeys(Map<String, String> metadataKeys) {
-         return new HashMap<>(metadataKeys.entrySet().stream()
+    private Map<String, List<String>> getQueryParamsFromMetadataKeys(Map<String, String> metadataKeys) {
+         return metadataKeys.entrySet().stream()
                 .collect(Collectors.toMap(
                         e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
                         e -> Collections.singletonList(e.getValue())
-                )));
+                ));
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -166,6 +166,10 @@ public class DatasetApi extends AbstractTargetedApi {
         return editMetadata(s, true);
     }
 
+    public DataverseResponse<DatasetVersion> editMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
+        return editMetadata(s, true, metadataKeys);
+    }
+
     /**
      * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
      * multiple values.
@@ -179,14 +183,7 @@ public class DatasetApi extends AbstractTargetedApi {
      */
     public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace) throws IOException, DataverseException {
         log.trace("ENTER");
-        HashMap<String, List<String>> queryParams = new HashMap<>();
-        if (replace)
-            /*
-             * Sic! any value for "replace" is interpreted by Dataverse as "true", even "replace=false"
-             * It is by the *absence* of the parameter that replace is set to false.
-             */
-            queryParams.put("replace", singletonList("true"));
-        return putToTarget("editMetadata", s, queryParams, DatasetVersion.class);
+        return editMetadata(s, replace, emptyMap());
     }
 
     /**
@@ -226,7 +223,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace) throws IOException, DataverseException {
-        return editMetadata(httpClientWrapper.writeValueAsString(fields), replace);
+        return editMetadata(fields, replace, emptyMap());
     }
 
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
@@ -243,12 +240,11 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields) throws IOException, DataverseException {
-        //return editMetadata(httpClientWrapper.writeValueAsString(fields), true);
         return editMetadata(fields, true, emptyMap());
     }
 
     public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        return editMetadata(httpClientWrapper.writeValueAsString(fields), true, metadataKeys);
+        return editMetadata(fields, true, metadataKeys);
     }
 
     // TODO https://guides.dataverse.org/en/latest/api/native-api.html#export-metadata-of-a-dataset-in-various-formats
@@ -266,8 +262,11 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace) throws IOException, DataverseException {
-        Map<String, List<String>> queryParams = singletonMap("replace", singletonList((String.valueOf(replace))));
-        return httpClientWrapper.putJsonLdString(subPath("metadata"), metadata, params(queryParams), extraHeaders, RoleAssignmentReadOnly.class);
+        return updateMetadataFromJsonLd(metadata, replace, emptyMap());
+    }
+
+    public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, Map<String, String> metadataKeys) throws IOException, DataverseException {
+        return updateMetadataFromJsonLd(metadata,true, metadataKeys);
     }
 
     /**
@@ -279,7 +278,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace, HashMap<String, String> metadataKeys) throws IOException, DataverseException {
+    public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
         HashMap<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         queryParams.put("replace", singletonList((String.valueOf(replace))));
         return httpClientWrapper.putJsonLdString(subPath("metadata"), metadata, params(queryParams), extraHeaders, RoleAssignmentReadOnly.class);
@@ -293,8 +292,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> updateMetadata(String s) throws IOException, DataverseException {
-        // Cheating with endPoint here, because the only version that can be updated is :draft anyway
-        return putToTarget("versions/:draft", s, emptyMap(), DatasetVersion.class);
+        return updateMetadata(s, emptyMap());
     }
 
     public DataverseResponse<DatasetVersion> updateMetadata(String s, Map<String, String> metadataKeys) throws IOException, DataverseException {
@@ -311,7 +309,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks) throws IOException, DataverseException {
-        return updateMetadata(httpClientWrapper.writeValueAsString(singletonMap("metadataBlocks", metadataBlocks)));
+        return updateMetadata(metadataBlocks, emptyMap());
     }
 
     public DataverseResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks, Map<String, String> metadataKeys) throws IOException, DataverseException {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -55,7 +55,7 @@ import static java.util.Collections.singletonMap;
 public class DatasetApi extends AbstractTargetedApi {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
-    private static final String metadataKeyParamNamePrefix = "mdkey.";
+    private static final String MDKEY_PARAM_NAME_PREFIX = "mdkey.";
     
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         this(httpClientWrapper, id, isPersistentId, null);
@@ -189,11 +189,24 @@ public class DatasetApi extends AbstractTargetedApi {
         return putToTarget("editMetadata", s, queryParams, DatasetVersion.class);
     }
 
+    /**
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
+     * multiple values. 
+     * Whenever there are metadata field from a block that is protected by a 'key', the corresponding keys must be provided. 
+     *
+     * @param s       JSON document containing the edits to perform
+     * @param replace whether to replace existing values
+     * @param metadataKeys  the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @return DatasetVersion
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
+     */
     public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace, HashMap<String, String> metadataKeys) throws IOException, DataverseException {
         log.trace("ENTER");
         HashMap<String, List<String>> queryParams = new HashMap<>(metadataKeys.entrySet().stream()
                 .collect(Collectors.toMap(
-                        e -> metadataKeyParamNamePrefix + e.getKey(),
+                        e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
                         e -> Collections.singletonList(e.getValue())
                 )));
         if (replace)

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -257,32 +257,108 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset, Collections.emptyMap(), Collections.emptyMap(), DatasetCreationResult.class);
+        return createDataset(dataset, Collections.emptyMap());
     }
 
-    /* https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection
+    /**
+     * @param dataset JSON string defining the dataset to create
+     * @param metadataKeys  the HashMap maps the names of the metadata blocks to their 'secret' key values
+     * @return a creation result message
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
+     */
+    public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset, Map<String, String> metadataKeys) throws IOException, DataverseException {
+        log.trace("ENTER");
+        Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
+        return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset, queryParams, Collections.emptyMap(), DatasetCreationResult.class);
+    }
+
+    /**
+     * @param dataset the dataset to create
+     * @return a creation result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset) throws IOException, DataverseException {
         log.trace("ENTER");
-        return createDataset(httpClientWrapper.writeValueAsString(dataset));
+        return createDataset(httpClientWrapper.writeValueAsString(dataset), Collections.emptyMap());
     }
 
-    /* https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection
+    /**
+     * @param dataset the dataset to create
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @return a creation result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset, Map<String, String> metadataKeys) throws IOException, DataverseException {
         log.trace("ENTER");
-        // TODO: implement
-        throw new UnsupportedOperationException();
+        return createDataset(httpClientWrapper.writeValueAsString(dataset), metadataKeys);
     }
 
+    /**
+     * @param dataset the dataset to import
+     * @param optPersistentId existing persistent identifier (PID)
+     * @param autoPublish immediately publish the dataset
+     * @return an import result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
-        return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish);
+        log.trace("ENTER");
+        return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, emptyMap());
     }
 
+    /**
+     * @param dataset the dataset to import
+     * @param optPersistentId existing persistent identifier (PID)
+     * @param autoPublish immediately publish the dataset
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @return an import result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
+     */
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys) throws IOException, DataverseException {
+        log.trace("ENTER");
+        return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, metadataKeys);
+    }
+
+    /**
+     * @param dataset JSON string defining the dataset to import
+     * @param optPersistentId existing persistent identifier (PID)
+     * @param autoPublish immediately publish the dataset
+     * @return an import result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
+     */
     public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish)
         throws IOException, DataverseException {
         log.trace("ENTER");
-        Map<String, List<String>> parameters = new HashMap<>();
+
+        return importDataset( dataset, optPersistentId, autoPublish, emptyMap());
+    }
+
+    /**
+     * @param dataset JSON string defining the dataset to import
+     * @param optPersistentId existing persistent identifier (PID)
+     * @param autoPublish immediately publish the dataset
+     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @return an import result message
+     * @throws IOException
+     * @throws DataverseException
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
+     */
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys) 
+            throws IOException, DataverseException {
+        log.trace("ENTER");
+        Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
+        Map<String, List<String>> parameters = new HashMap<>(queryParams);
         optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
         optPersistentId.ifPresent(pid -> parameters.put("pid", singletonList(pid)));
         return httpClientWrapper.postJsonString(subPath.resolve("datasets/:import"), dataset, parameters, emptyMap(), DatasetCreationResult.class);


### PR DESCRIPTION
Fixes DD-1313: Allow passing system metadata keys to editMetadata

# Description of changes
When the vault metadata block is protected with a sectret key, this key must be provided as query parameter when changing or creating fields in that metadata block. 

# How to test
Run the examples as described by `docs/examples.md`. To test with a key set this on the `citation` metadata block. 
 
# Related PRs

(Add links)

* https://github.com/DANS-KNAW/dd-vault-metadata/pull/9

# Notify

@DANS-KNAW/dataversedans
