### PR TITLE
Extend updateMetadata, consistent return types and more examples

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
@@ -58,12 +58,12 @@ public class DatasetUpdateMetadata extends ExampleBase {
             new ControlledMultiValueField("subject", Collections.singletonList("Chemistry"))
         ));
 
-        // Note that the dataset must be in draft state, otherwise it cannot be updated through this API.
+        // Note that if the dataset is not already in draft state, the draft created here will not be indexed.
         // You may initiate a draft for a new version by making a trivial change to the metadata using the editMetadata API
         try {
             DataverseResponse<DatasetLatestVersion> r = client.dataset(persistentId).getLatestVersion();
             DatasetVersion latest = r.getData().getLatestVersion();
-            latest.setTermsOfAccess("Blaaah");
+            latest.setTermsOfAccess("Some new terms. Pray I don't alter them any further.");
             latest.setFiles(Collections.emptyList());
             latest.setMetadataBlocks(Collections.singletonMap("citation", citation));
             var r2 = client.dataset(persistentId).updateMetadata(latest);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.ControlledMultiValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetLatestVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
@@ -60,10 +61,14 @@ public class DatasetUpdateMetadata extends ExampleBase {
         // Note that the dataset must be in draft state, otherwise it cannot be updated through this API.
         // You may initiate a draft for a new version by making a trivial change to the metadata using the editMetadata API
         try {
-
-            DataverseResponse<DatasetVersion> r = client.dataset(persistentId).updateMetadata(Collections.singletonMap("citation", citation));
-            log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
-            log.info("Version number: {}", r.getData().getVersionNumber());
+            DataverseResponse<DatasetLatestVersion> r = client.dataset(persistentId).getLatestVersion();
+            DatasetVersion latest = r.getData().getLatestVersion();
+            latest.setTermsOfAccess("Blaaah");
+            latest.setFiles(Collections.emptyList());
+            latest.setMetadataBlocks(Collections.singletonMap("citation", citation));
+            var r2 = client.dataset(persistentId).updateMetadata(latest);
+            log.info("Response message: {}", r2.getEnvelopeAsJson().toPrettyString());
+            log.info("Version number: {}", r2.getData().getVersionNumber());
         } catch (DataverseException e) {
             System.out.println(e.getMessage());
         }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
@@ -26,6 +26,7 @@ import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,15 +38,14 @@ public class DatasetUpdateMetadataFromJsonLd extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
+        URI licenseUri = new URI(args[1]);
 
-        var dvCore = "https://dataverse.org/schema/core#";
-        Map<String, Object> fileTermsOfAccessValue = new HashMap<>();
+        var licenseObject = Map.of("http://schema.org/license", licenseUri);
+        var jsonLd = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(licenseObject);
 
-        fileTermsOfAccessValue.put(dvCore + "termsOfAccess", "N/a");
-        fileTermsOfAccessValue.put(dvCore + "fileRequestAccess", false);
-
-        var jsonLd = mapper.writeValueAsString(Collections.singletonMap(dvCore + "fileTermsOfAccess", fileTermsOfAccessValue));
+        log.info("--- BEGIN JSON OBJECT ---");
         System.out.println(jsonLd);
+        log.info("--- END JSON OBJECT ---");
 
         try {
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.dataset.ControlledMultiValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
+import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DatasetUpdateMetadataFromJsonLd extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetUpdateMetadataFromJsonLd.class);
+
+    public static void main(String[] args) throws Exception {
+        String persistentId = args[0];
+
+        var dvCore = "https://dataverse.org/schema/core#";
+        Map<String, Object> fileTermsOfAccessValue = new HashMap<>();
+
+        fileTermsOfAccessValue.put(dvCore + "termsOfAccess", "N/a");
+        fileTermsOfAccessValue.put(dvCore + "fileRequestAccess", false);
+
+        var jsonLd = mapper.writeValueAsString(Collections.singletonMap(dvCore + "fileTermsOfAccess", fileTermsOfAccessValue));
+        System.out.println(jsonLd);
+
+        try {
+
+            DataverseResponse<Object> r = client.dataset(persistentId)
+                .updateMetadataFromJsonLd(jsonLd, true);
+            log.info("Response message: {}", r.getEnvelopeAsJson().toPrettyString());
+        }
+        catch (DataverseException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
@@ -49,7 +49,7 @@ public class AdminApi extends AbstractApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-single-user" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<AuthenticatedUser> listSingleUser(String id) throws IOException, DataverseException {
+    public DataverseHttpResponse<AuthenticatedUser> listSingleUser(String id) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "authenticatedUsers", id);
         return httpClientWrapper.get(path, new HashMap<>(), new HashMap<>(), AuthenticatedUser.class);
     }
@@ -62,7 +62,7 @@ public class AdminApi extends AbstractApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/installation/config.html#database-settings" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<Map<String, String>> putDatabaseSetting(String key, String value) throws IOException, DataverseException {
+    public DataverseHttpResponse<Map<String, String>> putDatabaseSetting(String key, String value) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "settings", key);
         return httpClientWrapper.putJsonString(path, value, new HashMap<>(), new HashMap<>(), Map.class);
     }
@@ -74,7 +74,7 @@ public class AdminApi extends AbstractApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/installation/config.html#database-settings" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DataMessage> getDatabaseSetting(String key) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> getDatabaseSetting(String key) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "settings", key);
         return httpClientWrapper.get(path, DataMessage.class);
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
@@ -44,18 +44,18 @@ public class DataAccessRequestsApi extends AbstractTargetedApi {
     }
 
 
-    public DataverseResponse<DataMessage> enable() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> enable() throws IOException, DataverseException {
         log.trace("ENTER");
         return toggle("true");
     }
 
-    public DataverseResponse<DataMessage> disable() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> disable() throws IOException, DataverseException {
         log.trace("ENTER");
         return toggle("false");
     }
 
 
-    private DataverseResponse<DataMessage> toggle(String bool) throws IOException, DataverseException {
+    private DataverseHttpResponse<DataMessage> toggle(String bool) throws IOException, DataverseException {
         headers.putAll(extraHeaders);
         return httpClientWrapper.putTextString(subPath, bool, params, headers, DataMessage.class);
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -77,8 +77,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Retrieves that latest version of a dataset. The difference with {@link #getLatestVersion()} is that the latter returns a different type
-     * of object. It is not clear why these variants exist.
+     * Retrieves that latest version of a dataset. The difference with {@link #getLatestVersion()} is that the latter returns a different type of object. It is not clear why these variants exist.
      *
      * @return object containing the dataset version metadata
      * @throws IOException        if an I/O exception occurs
@@ -115,10 +114,10 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
+     * @param version version to get file metadata from
      * @return a list of file metas
      * @throws IOException        if an I/O exception occurs
      * @throws DataverseException if Dataverse could not handle the request
-     * @param version version to get file metadata from
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<FileMeta>> getFiles(String version) throws IOException, DataverseException {
@@ -154,8 +153,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
-     * multiple values.
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
      *
      * @param s JSON document containing the edits to perform
      * @return DatasetVersion
@@ -168,8 +166,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
-     * multiple values.
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
      *
      * @param s       JSON document containing the edits to perform
      * @param replace whether to replace existing values
@@ -191,8 +188,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
-     * multiple values.
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
      *
      * @param fields  list of fields to edit
      * @param replace whether to replace existing values
@@ -226,7 +222,7 @@ public class DatasetApi extends AbstractTargetedApi {
 
     /**
      * @param metadata JSON document describing the metadata
-     * @param replace replace existing metadata
+     * @param replace  replace existing metadata
      * @return a generic DataverseHttpResponse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -250,20 +246,19 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * @param metadataBlocks map of metadata block name to metadata block
+     * Note that not all the attributes of the DatasetVersion object are writable. Dataverse may ignore some (e.g., license) or return an error if some are filled in (e.g., files).
+     * However, for a few attributes, such as fileAccessRequest and termsOfAccess, it is necessary to pass the whole version object instead of only
+     * the metadata blocks (as is done in the example of the API documentation).
+     *
+     * @param version a version object containing the new metadata
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks) throws IOException, DataverseException {
-        return updateMetadata(httpClientWrapper.writeValueAsString(singletonMap("metadataBlocks", metadataBlocks)));
-    }
-
     public DataverseHttpResponse<DatasetVersion> updateMetadata(DatasetVersion version) throws IOException, DataverseException {
         return updateMetadata(httpClientWrapper.writeValueAsString(version));
     }
-
 
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-metadata
 
@@ -444,10 +439,8 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions in this library, this does not correspond directly with an API
-     * call. Rather the
-     * {@link #getLocks()} call is done repeatedly to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset it is
-     * not guaranteed that
+     * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions in this library, this does not correspond directly with an API call. Rather the
+     * {@link #getLocks()} call is done repeatedly to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset it is not guaranteed that
      * the locks, once cleared, stay that way.
      *
      * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
@@ -471,11 +464,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Utility function that lets you wait until a specified lock type is set. Unlike most other functions in this library, this does not correspond directly with an API call.
-     * Rather the {@link
-     * #getLocks()} call is done repeatedly to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been locked on its
-     * behalf, so that it can
-     * be sure to have exclusive access via its invocation ID.
+     * Utility function that lets you wait until a specified lock type is set. Unlike most other functions in this library, this does not correspond directly with an API call. Rather the
+     * {@link #getLocks()} call is done repeatedly to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been locked on its behalf, so that
+     * it can be sure to have exclusive access via its invocation ID.
      *
      * @param lockType               the lock type to wait for
      * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to #awawaitLockStateMaxNumberOfRetries
@@ -520,8 +511,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs within `maxNumberOrRetries` with
-     * `waitTimeInMilliseconds`
+     * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs within `maxNumberOrRetries` with `waitTimeInMilliseconds`
      * pauses.
      *
      * @param lockState              the function that returns whether the required state has been reached

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -72,7 +72,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-json-representation-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetLatestVersion> getLatestVersion() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetLatestVersion> getLatestVersion() throws IOException, DataverseException {
         return getUnversionedFromTarget("", DatasetLatestVersion.class);
     }
 
@@ -85,7 +85,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> getVersion() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> getVersion() throws IOException, DataverseException {
         // Not specifying a version results in getting all versions.
         return getVersionedFromTarget("", Version.LATEST.toString(), DatasetVersion.class);
     }
@@ -97,7 +97,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#get-version-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> getVersion(String version) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> getVersion(String version) throws IOException, DataverseException {
         if (StringUtils.isBlank(version))
             throw new IllegalArgumentException("Argument 'version' may not be empty");
         return getVersionedFromTarget("", version, DatasetVersion.class);
@@ -109,7 +109,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-versions-of-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<List<DatasetVersion>> getAllVersions() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<DatasetVersion>> getAllVersions() throws IOException, DataverseException {
         // Not specifying a version results in getting all versions.
         return getVersionedFromTarget("", "", List.class, DatasetVersion.class);
     }
@@ -121,7 +121,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @param version version to get file metadata from
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<List<FileMeta>> getFiles(String version) throws IOException, DataverseException {
+    public DataverseHttpResponse<List<FileMeta>> getFiles(String version) throws IOException, DataverseException {
         log.trace("ENTER");
         return getVersionedFromTarget("files", version, List.class, FileMeta.class);
     }
@@ -132,7 +132,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException if Dataverse could not handle the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetPublicationResult> publish() throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetPublicationResult> publish() throws IOException, DataverseException {
         Path path = buildPath(targetBase, persistendId, publish);
         HashMap<String, List<String>> parameters = new HashMap<>();
         parameters.put("persistentId", singletonList(id));
@@ -148,7 +148,7 @@ public class DatasetApi extends AbstractTargetedApi {
         return httpClientWrapper.postJsonString(subPath(publish), "", params(parameters), new HashMap<>(), DataMessage.class);
     }
 
-    public DataverseResponse<DatasetPublicationResult> releaseMigrated(String publicationDateJsonLd, boolean assureIsIndexed) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetPublicationResult> releaseMigrated(String publicationDateJsonLd, boolean assureIsIndexed) throws IOException, DataverseException {
         Map<String, List<String>> parameters = singletonMap("assureIsIndexed", singletonList(String.valueOf(assureIsIndexed)));
         return httpClientWrapper.postJsonLdString(subPath("actions/:releasemigrated"), publicationDateJsonLd, params(parameters), emptyMap(), DatasetPublicationResult.class);
     }
@@ -163,7 +163,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> editMetadata(String s) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> editMetadata(String s) throws IOException, DataverseException {
         return editMetadata(s, true);
     }
 
@@ -178,7 +178,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> editMetadata(String s, Boolean replace) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> editMetadata(String s, Boolean replace) throws IOException, DataverseException {
         log.trace("ENTER");
         HashMap<String, List<String>> queryParams = new HashMap<>();
         if (replace)
@@ -201,7 +201,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> editMetadata(FieldList fields, Boolean replace) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), replace);
     }
 
@@ -214,7 +214,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> editMetadata(FieldList fields) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> editMetadata(FieldList fields) throws IOException, DataverseException {
         return editMetadata(httpClientWrapper.writeValueAsString(fields), true);
     }
 
@@ -227,12 +227,12 @@ public class DatasetApi extends AbstractTargetedApi {
     /**
      * @param metadata JSON document describing the metadata
      * @param replace replace existing metadata
-     * @return a generic DataverseResponse
+     * @return a generic DataverseHttpResponse
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/developers/dataset-semantic-metadata-api.html#add-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace) throws IOException, DataverseException {
+    public DataverseHttpResponse<Object> updateMetadataFromJsonLd(String metadata, boolean replace) throws IOException, DataverseException {
         Map<String, List<String>> queryParams = singletonMap("replace", singletonList((String.valueOf(replace))));
         return httpClientWrapper.putJsonLdString(subPath("metadata"), metadata, params(queryParams), extraHeaders, RoleAssignmentReadOnly.class);
     }
@@ -244,7 +244,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> updateMetadata(String s) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> updateMetadata(String s) throws IOException, DataverseException {
         // Cheating with endPoint here, because the only version that can be updated is :draft anyway
         return putToTarget("versions/:draft", s, emptyMap(), DatasetVersion.class);
     }
@@ -256,9 +256,14 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#update-metadata-for-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks) throws IOException, DataverseException {
+    public DataverseHttpResponse<DatasetVersion> updateMetadata(Map<String, MetadataBlock> metadataBlocks) throws IOException, DataverseException {
         return updateMetadata(httpClientWrapper.writeValueAsString(singletonMap("metadataBlocks", metadataBlocks)));
     }
+
+    public DataverseHttpResponse<DatasetVersion> updateMetadata(DatasetVersion version) throws IOException, DataverseException {
+        return updateMetadata(httpClientWrapper.writeValueAsString(version));
+    }
+
 
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-metadata
 
@@ -268,7 +273,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<DataMessage> deleteDraft() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> deleteDraft() throws IOException, DataverseException {
         log.trace("ENTER");
         return httpClientWrapper.delete(subPath("versions/:draft"), params(emptyMap()), DataMessage.class);
     }
@@ -294,11 +299,11 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<RoleAssignmentReadOnly> assignRole(String roleAssignment) throws IOException, DataverseException {
+    public DataverseHttpResponse<RoleAssignmentReadOnly> assignRole(String roleAssignment) throws IOException, DataverseException {
         return httpClientWrapper.postJsonString(subPath("assignments"), roleAssignment, params(emptyMap()), extraHeaders, RoleAssignmentReadOnly.class);
     }
 
-    public DataverseResponse<RoleAssignmentReadOnly> assignRole(RoleAssignment roleAssignment) throws IOException, DataverseException {
+    public DataverseHttpResponse<RoleAssignmentReadOnly> assignRole(RoleAssignment roleAssignment) throws IOException, DataverseException {
         return assignRole(httpClientWrapper.writeValueAsString(roleAssignment));
     }
 
@@ -315,7 +320,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<FileList> addFile(Path file, String metadata) throws IOException, DataverseException {
+    public DataverseHttpResponse<FileList> addFile(Path file, String metadata) throws IOException, DataverseException {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         Optional.ofNullable(file).ifPresent(f -> builder.addPart("file", new FileBody(f.toFile(), ContentType.APPLICATION_OCTET_STREAM, f.getFileName().toString())));
         Optional.ofNullable(metadata).ifPresent(m -> builder.addPart("jsonData", new StringBody(m, ContentType.APPLICATION_JSON)));
@@ -330,7 +335,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<FileList> addFile(Path file, FileMeta fileMeta) throws IOException, DataverseException {
+    public DataverseHttpResponse<FileList> addFile(Path file, FileMeta fileMeta) throws IOException, DataverseException {
         return addFile(file, httpClientWrapper.writeValueAsString(fileMeta));
     }
 
@@ -420,7 +425,7 @@ public class DatasetApi extends AbstractTargetedApi {
         return getUnversionedFromTarget(endPoint, emptyMap(), outputClass);
     }
 
-    private <D> DataverseResponse<D> putToTarget(String endPoint, String body, Map<String, List<String>> queryParams, Class<?>... outputClass)
+    private <D> DataverseHttpResponse<D> putToTarget(String endPoint, String body, Map<String, List<String>> queryParams, Class<?>... outputClass)
         throws IOException, DataverseException {
         log.trace("ENTER");
         return httpClientWrapper.putJsonString(subPath(endPoint), body, params(queryParams), extraHeaders, outputClass);
@@ -433,7 +438,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks" target="_blank">...</a>
      * @see <a href="https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/master/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java">Code example</a>
      */
-    public DataverseResponse<List<Lock>> getLocks() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<Lock>> getLocks() throws IOException, DataverseException {
         log.trace("getting locks from Dataverse");
         return getUnversionedFromTarget("locks", List.class, Lock.class);
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
@@ -43,35 +43,35 @@ public class LicenseApi extends AbstractApi {
         this.targetBase = Paths.get("api/licenses/");
     }
 
-    public DataverseResponse<List<License>> getLicenses() throws IOException, DataverseException {
+    public DataverseHttpResponse<List<License>> getLicenses() throws IOException, DataverseException {
         return httpClientWrapper.get(targetBase, List.class, License.class);
     }
 
-    public DataverseResponse<License> getLicenseById(long id) throws IOException, DataverseException {
+    public DataverseHttpResponse<License> getLicenseById(long id) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "" + id);
         return httpClientWrapper.get(path, License.class);
     }
 
-    public DataverseResponse<DataMessage> addLicense(CreateLicense license) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> addLicense(CreateLicense license) throws IOException, DataverseException {
         return httpClientWrapper.postModelObjectAsJson(targetBase, license, DataMessage.class);
     }
 
-    public DataverseResponse<DataMessage> getDefaultLicense() throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> getDefaultLicense() throws IOException, DataverseException {
         Path path = buildPath(targetBase, "default");
         return httpClientWrapper.get(path, DataMessage.class);
     }
 
-    public DataverseResponse<DataMessage> setDefaultLicense(long id) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> setDefaultLicense(long id) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "" + id);
         return httpClientWrapper.putJsonString(path, "", Map.of(), Map.of(), DataMessage.class);
     }
 
-    public DataverseResponse<DataMessage> setActiveState(long id, boolean active) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> setActiveState(long id, boolean active) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "" + id, ":active", "" + active);
         return httpClientWrapper.putJsonString(path, "", Map.of(), Map.of(), DataMessage.class);
     }
 
-    public DataverseResponse<DataMessage> deleteLicense(long id) throws IOException, DataverseException {
+    public DataverseHttpResponse<DataMessage> deleteLicense(long id) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "" + id);
         return httpClientWrapper.delete(path, DataMessage.class);
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
@@ -45,7 +45,7 @@ public class SearchApi extends AbstractApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/search.html" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<SearchResult> find(String query) throws IOException, DataverseException {
+    public DataverseHttpResponse<SearchResult> find(String query) throws IOException, DataverseException {
         return find(query, new SearchOptions());
     }
 
@@ -59,7 +59,7 @@ public class SearchApi extends AbstractApi {
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/search.html" target="_blank">Dataverse documentation</a>
      */
-    public DataverseResponse<SearchResult> find(String query, SearchOptions options)
+    public DataverseHttpResponse<SearchResult> find(String query, SearchOptions options)
         throws IOException, DataverseException {
         Map<String, List<String>> parameters = new HashMap<>();
         parameters.put("q", Collections.singletonList(query));

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
@@ -19,6 +19,8 @@ import lombok.Data;
 import nl.knaw.dans.lib.dataverse.model.file.prestaged.Checksum;
 import nl.knaw.dans.lib.dataverse.model.file.prestaged.PrestagedFile;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 @Data
@@ -30,7 +32,7 @@ public class FileMeta {
     private int version;
     private int datasetVersionId;
     private Boolean restricted;
-    private List<String> categories;
+    private List<String> categories = new ArrayList<>();
     private DataFile dataFile;
     private Boolean forceReplace;
 


### PR DESCRIPTION
Fixes DD-

# Description of changes
* Changed `DataverseResponse` to `DataverseHttpResponse` in many API methods. This was not consistently done yet. The latter is a subclass of the former, which lets the caller access the low-level http response directly.
* Added example `DatasetUpdateMetadataFromJsonLd.java`, to show how to update the license.
* Changed `updateMetadata` to take a version object instead of only the metadata blocks, so that you can set fileAccessRequest and termsOfAccess using this method.

# How to test
Run the examples.

# Related PRs
*

# Notify

@DANS-KNAW/dataversedans
