### PR TITLE
Cleanup

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminGetDatabaseSetting.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminGetDatabaseSetting.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class AdminGetDatabaseSetting extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(AdminGetDatabaseSetting.class);
 
     public static void main(String[] args) throws Exception {
         String key = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminListSingleUser.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminListSingleUser.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class AdminListSingleUser extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(AdminListSingleUser.class);
 
     public static void main(String[] args) throws Exception {
         String userId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminPutDatabaseSetting.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminPutDatabaseSetting.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
@@ -22,9 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+@Slf4j
 public class AdminPutDatabaseSetting extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(AdminPutDatabaseSetting.class);
 
     public static void main(String[] args) throws Exception {
         String key = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/BasicFileAccessGetFile.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/BasicFileAccessGetFile.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.GetFileRange;
 import org.apache.commons.io.FileUtils;
@@ -25,9 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+@Slf4j
 public class BasicFileAccessGetFile extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(BasicFileAccessGetFile.class);
 
     public static void main(String[] args) throws Exception {
         int id = Integer.parseInt(args[0]);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAddFile.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAddFile.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
@@ -25,10 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+@Slf4j
 public class DatasetAddFile extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetAddFile.class);
-
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
         Path file = Paths.get(args[1]);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitLock.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DatasetAwaitLock extends ExampleBase {
 
-    private static final Logger log = LoggerFactory.getLogger(DatasetAwaitLock.class);
-
-    /**
+    /*
      * The easiest way to test this manually is to create an InReview lock. Other locks will be released too quickly.
      *
      * 1. Create a dataset.

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetAwaitUnlock.java
@@ -15,14 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DatasetAwaitUnlock extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DatasetAwaitUnlock.class);
-
-    /**
+    /*
      * The easiest way to test this manually is to create an InReview lock. Other locks will be released too quickly.
      *
      * 1. Create a dataset.

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetEditMetadata.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
@@ -25,9 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 
+@Slf4j
 public class DatasetEditMetadata extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetEditMetadata.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
@@ -37,7 +37,7 @@ public class DatasetEditMetadata extends ExampleBase {
         if (args.length > 2) {
             var mdKeyValue = args[2];
             keyMap.put("citation", mdKeyValue);
-            System.out.println("Supplied citation metadata key: " + mdKeyValue );
+            System.out.println("Supplied citation metadata key: " + mdKeyValue);
         }
 
         FieldList fieldList = new FieldList();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetAllVersions.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetAllVersions.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
@@ -24,9 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DatasetGetAllVersions extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetGetAllVersions.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
@@ -37,7 +37,7 @@ public class DatasetGetAllVersions extends ExampleBase {
             DatasetVersion firstVersion = r.getData().get(0);
             log.info("First Version Create Time: {}", firstVersion.getCreateTime());
             log.info("First Version State: {}", firstVersion.getVersionState());
-            for (FileMeta fm: firstVersion.getFiles()) {
+            for (FileMeta fm : firstVersion.getFiles()) {
                 log.info("File Label: {}", fm.getLabel());
                 log.info("File UNF (if present): {}", fm.getDataFile().getUnf());
             }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetFiles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetFiles.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DatasetGetFiles extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetGetFiles.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLatestVersion.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLatestVersion.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetLatestVersion;
@@ -22,9 +23,8 @@ import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DatasetGetLatestVersion extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetGetLatestVersion.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.Lock;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DatasetGetLocks extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetGetLocks.class);
 
     public static void main(String[] args) throws Exception {
         /*

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java
@@ -38,7 +38,7 @@ public class DatasetGetLocks extends ExampleBase {
         for (int i = 0; i < 300; i += 1) {
             DataverseResponse<List<Lock>> response = client.dataset(persistentId).getLocks();
             List<Lock> locks = response.getData();
-            log.trace(String.format("Locks: %s", locks));
+            log.debug(String.format("Locks: %s", locks));
             if (!locks.isEmpty())
                 log.info(String.format("Dataset is currently locked by: %s", locks));
             Thread.sleep(500);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetVersion.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DatasetApi;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
@@ -22,9 +23,8 @@ import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DatasetGetVersion extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetGetVersion.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetListRoleAssignments.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetListRoleAssignments.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignmentReadOnly;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DatasetListRoleAssignments extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetListRoleAssignments.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetPublish.java
@@ -15,16 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.DatasetPublicationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+@Slf4j
 public class DatasetPublish extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetPublish.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadata.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
@@ -31,9 +32,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
+@Slf4j
 public class DatasetUpdateMetadata extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetUpdateMetadata.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];
@@ -41,7 +41,7 @@ public class DatasetUpdateMetadata extends ExampleBase {
         if (args.length > 1) {
             var mdKeyValue = args[1];
             keyMap.put("citation", mdKeyValue);
-            System.out.println("Supplied citation metadata key: " + mdKeyValue );
+            System.out.println("Supplied citation metadata key: " + mdKeyValue);
         }
 
         MetadataBlock citation = new MetadataBlock();
@@ -76,7 +76,8 @@ public class DatasetUpdateMetadata extends ExampleBase {
             var r2 = client.dataset(persistentId).updateMetadata(latest, keyMap);
             log.info("Response message: {}", r2.getEnvelopeAsJson().toPrettyString());
             log.info("Version number: {}", r2.getData().getVersionNumber());
-        } catch (DataverseException e) {
+        }
+        catch (DataverseException e) {
             System.out.println(e.getMessage());
         }
     }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetUpdateMetadataFromJsonLd.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
@@ -32,9 +33,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class DatasetUpdateMetadataFromJsonLd extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DatasetUpdateMetadataFromJsonLd.class);
 
     public static void main(String[] args) throws Exception {
         String persistentId = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreate.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
@@ -25,9 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
+@Slf4j
 public class DataverseCreate extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseCreate.class);
 
     public static void main(String[] args) throws Exception {
         Dataverse dataverse = new Dataverse();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseCreateDataset.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
@@ -34,15 +35,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
+@Slf4j
 public class DataverseCreateDataset extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataverseCreateDataset.class);
-
     public static void main(String[] args) throws Exception {
         var keyMap = new HashMap<String, String>();
         if (args.length > 0) {
             var mdKeyValue = args[0];
             keyMap.put("citation", mdKeyValue);
-            System.out.println("Supplied citation metadata key: " + mdKeyValue );
+            System.out.println("Supplied citation metadata key: " + mdKeyValue);
         }
 
         MetadataBlock citation = new MetadataBlock();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseDelete.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseDelete.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataverseDelete extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseDelete.class);
 
     public static void main(String[] args) throws Exception {
         DataverseHttpResponse<DataMessage> r = client.dataverse("test").delete();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseGetContents.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseGetContents.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseDatasetItem;
@@ -26,9 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DataverseGetContents extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseGetContents.class);
 
     public static void main(String[] args) throws Exception {
         DataverseHttpResponse<List<DataverseItem>> r = client.dataverse("root").getContents();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseGetStorageSize.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseGetStorageSize.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataverseGetStorageSize extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseGetStorageSize.class);
 
     public static void main(String[] args) throws Exception {
         DataverseHttpResponse<DataMessage> r = client.dataverse("root").getStorageSize();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
@@ -19,11 +19,18 @@ import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
-import nl.knaw.dans.lib.dataverse.model.dataset.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import nl.knaw.dans.lib.dataverse.model.dataset.ControlledMultiValueField;
+import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetCreationResult;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
+import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
 
 @Slf4j
 public class DataverseImportDataset extends ExampleBase {
@@ -72,9 +79,9 @@ public class DataverseImportDataset extends ExampleBase {
         log.info("--- END JSON OBJECT ---");
 
         UUID uuid = UUID.randomUUID();
-        Optional<String> optDoi = Optional.of("doi:10.5072/EDDA-RAGNAROK/IMPORTTEST-" + uuid.toString());
+        var doi = String.format("doi:10.5072/EDDA-RAGNAROK/IMPORTTEST-%s", uuid);
         DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").importDataset(dataset,
-            optDoi, false, keyMap);
+            doi, false, keyMap);
         log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
     }
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseImportDataset.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
@@ -24,15 +25,14 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+@Slf4j
 public class DataverseImportDataset extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataverseImportDataset.class);
-
     public static void main(String[] args) throws Exception {
         var keyMap = new HashMap<String, String>();
         if (args.length > 0) {
             var mdKeyValue = args[0];
             keyMap.put("citation", mdKeyValue);
-            System.out.println("Supplied citation metadata key: " + mdKeyValue );
+            System.out.println("Supplied citation metadata key: " + mdKeyValue);
         }
 
         MetadataBlock citation = new MetadataBlock();
@@ -41,14 +41,14 @@ public class DataverseImportDataset extends ExampleBase {
 
         MetadataField title = new PrimitiveSingleValueField("title", "Test imported dataset");
         MetadataField description = new CompoundFieldBuilder("dsDescription", true)
-                .addSubfield("dsDescriptionValue", "Test description")
-                .addSubfield("dsDescriptionDate", "").build();
+            .addSubfield("dsDescriptionValue", "Test description")
+            .addSubfield("dsDescriptionDate", "").build();
         MetadataField author = new CompoundFieldBuilder("author", true)
-                .addSubfield("authorName", "P E Loki")
-                .addSubfield("authorAffiliation", "Walhalla").build();
+            .addSubfield("authorName", "P E Loki")
+            .addSubfield("authorAffiliation", "Walhalla").build();
         MetadataField contact = new CompoundFieldBuilder("datasetContact", true)
-                .addSubfield("datasetContactName", "Test Contact")
-                .addSubfield("datasetContactEmail", "test@example.com").build();
+            .addSubfield("datasetContactName", "Test Contact")
+            .addSubfield("datasetContactEmail", "test@example.com").build();
         MetadataField subjects = new ControlledMultiValueField("subject", Arrays.asList("Arts and Humanities", "Computer and Information Science"));
 
         citation.setFields(Arrays.asList(title, author, contact, description, subjects));
@@ -73,8 +73,8 @@ public class DataverseImportDataset extends ExampleBase {
 
         UUID uuid = UUID.randomUUID();
         Optional<String> optDoi = Optional.of("doi:10.5072/EDDA-RAGNAROK/IMPORTTEST-" + uuid.toString());
-        DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").importDataset(dataset, 
-                optDoi, false, keyMap);
+        DataverseHttpResponse<DatasetCreationResult> r = client.dataverse("root").importDataset(dataset,
+            optDoi, false, keyMap);
         log.info("Status Line: {}", r.getHttpResponse().getStatusLine());
     }
 

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseIsMetadataBlocksRoot.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseIsMetadataBlocksRoot.java
@@ -15,14 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataverseIsMetadataBlocksRoot extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseIsMetadataBlocksRoot.class);
 
     public static void main(String[] args) throws Exception {
         String alias = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoleAssignments.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoleAssignments.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignmentReadOnly;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DataverseListRoleAssignments extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseListRoleAssignments.class);
 
     public static void main(String[] args) throws Exception {
         DataverseHttpResponse<List<RoleAssignmentReadOnly>> r = client.dataverse("root").listRoleAssignments();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseListRoles.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.Role;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+@Slf4j
 public class DataverseListRoles extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseListRoles.class);
 
     public static void main(String[] args) throws Exception {
         DataverseHttpResponse<List<Role>> r = client.dataverse("root").listRoles();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataversePublish.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataversePublish extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
 
     public static void main(String[] args) throws Exception {
         // Notice: the test dataverse instance has to exist before calling this method

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseSetMetadataBlocksRoot.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseHttpResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataverseSetMetadataBlocksRoot extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DataverseSetMetadataBlocksRoot.class);
 
     public static void main(String[] args) throws Exception {
         String alias = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseView.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DataverseView.java
@@ -15,15 +15,15 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataverse.Dataverse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class DataverseView extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataverseView.class);
-
     public static void main(String[] args) throws Exception {
         DataverseResponse<Dataverse> r = client.dataverse("root").view();
         log.info("Response message = {}", r.getEnvelopeAsJson().toPrettyString());

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
@@ -17,9 +17,15 @@ package nl.knaw.dans.lib.dataverse.example;
 
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.swing.text.html.Option;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
 
 public class FileReplace extends ExampleBase {
 
@@ -27,13 +33,13 @@ public class FileReplace extends ExampleBase {
 
     public static void main(String[] args) throws Exception {
         int databaseId = Integer.parseInt(args[0]);
-        String newName = args[1];
-        String newDir = args[2];
-        FileMeta meta = new FileMeta();
-        meta.setLabel(newName);
-        meta.setDirectoryLabel(newDir);
+        Path newFile = Paths.get(args[1]);
 
-        DataverseResponse<String> r = client.file(databaseId).updateMetadata(mapper.writeValueAsString(meta));
+        var meta = new FileMeta();
+        meta.setLabel("New_label");
+        var metaStr = mapper.writeValueAsString(meta);
+
+        DataverseResponse<FileList> r = client.file(databaseId).replaceFileItem(Optional.of(newFile.toFile()), Optional.of(metaStr));
         log.info("Response message: {}", r.getEnvelopeAsString());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileReplace extends ExampleBase {
+
+    private static final Logger log = LoggerFactory.getLogger(FileReplace.class);
+
+    public static void main(String[] args) throws Exception {
+        int databaseId = Integer.parseInt(args[0]);
+        String newName = args[1];
+        String newDir = args[2];
+        FileMeta meta = new FileMeta();
+        meta.setLabel(newName);
+        meta.setDirectoryLabel(newDir);
+
+        DataverseResponse<String> r = client.file(databaseId).updateMetadata(mapper.writeValueAsString(meta));
+        log.info("Response message: {}", r.getEnvelopeAsString());
+    }
+}

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
@@ -20,13 +20,9 @@ import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.swing.text.html.Option;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Optional;
 
 @Slf4j
 public class FileReplace extends ExampleBase {
@@ -37,9 +33,8 @@ public class FileReplace extends ExampleBase {
 
         var meta = new FileMeta();
         meta.setLabel("New_label");
-        var metaStr = mapper.writeValueAsString(meta);
 
-        DataverseResponse<FileList> r = client.file(databaseId).replaceFileItem(Optional.of(newFile.toFile()), Optional.of(metaStr));
+        DataverseResponse<FileList> r = client.file(databaseId).replaceFile(newFile, meta);
         log.info("Response message: {}", r.getEnvelopeAsString());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileReplace.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
@@ -27,9 +28,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+@Slf4j
 public class FileReplace extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(FileReplace.class);
 
     public static void main(String[] args) throws Exception {
         int databaseId = Integer.parseInt(args[0]);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileUpdateMetadata.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
@@ -25,9 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 public class FileUpdateMetadata extends ExampleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(FileUpdateMetadata.class);
 
     public static void main(String[] args) throws Exception {
         int databaseId = Integer.parseInt(args[0]);

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileUpdateMetadata.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/FileUpdateMetadata.java
@@ -19,12 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 public class FileUpdateMetadata extends ExampleBase {
@@ -37,7 +31,7 @@ public class FileUpdateMetadata extends ExampleBase {
         meta.setLabel(newName);
         meta.setDirectoryLabel(newDir);
 
-        DataverseResponse<String> r = client.file(databaseId).updateMetadata(mapper.writeValueAsString(meta));
+        DataverseResponse<String> r = client.file(databaseId).updateMetadata(meta);
         log.info("Response message: {}", r.getEnvelopeAsString());
     }
 }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesCreate.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesCreate.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.license.CreateLicense;
 import nl.knaw.dans.lib.dataverse.model.license.License;
@@ -23,9 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
+@Slf4j
 public class LicensesCreate extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
-
     public static void main(String[] args) throws Exception {
         log.info("--- BEGIN JSON OBJECT ---");
         var id = UUID.randomUUID().toString();

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesDelete.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesDelete.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.license.CreateLicense;
 import org.slf4j.Logger;
@@ -22,9 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
+@Slf4j
 public class LicensesDelete extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
-
     public static void main(String[] args) throws Exception {
         log.info("--- BEGIN JSON OBJECT ---");
         var id = args.length > 0 ? Long.parseLong(args[0]) : 26;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesGetDefault.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesGetDefault.java
@@ -15,13 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class LicensesGetDefault extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
-
     public static void main(String[] args) throws Exception {
         log.info("--- BEGIN JSON OBJECT ---");
         var id = args.length > 1 ? Long.parseLong(args[1]) : 1;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesGetSingle.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesGetSingle.java
@@ -15,13 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class LicensesGetSingle extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
-
     public static void main(String[] args) throws Exception {
         log.info("--- BEGIN JSON OBJECT ---");
         var id = args.length > 1 ? Long.parseLong(args[1]) : 1;

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesList.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/LicensesList.java
@@ -15,19 +15,19 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class LicensesList extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(DataversePublish.class);
-
     public static void main(String[] args) throws Exception {
         log.info("--- BEGIN JSON OBJECT ---");
         var response = client.license().getLicenses();
         log.info("--- END JSON OBJECT ---");
 
-        for (var r: response.getData()) {
+        for (var r : response.getData()) {
             log.info("License: {}", r);
         }
     }

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/SearchFind.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/SearchFind.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.SearchOptions;
@@ -31,9 +32,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class SearchFind extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(SearchFind.class);
-
     public static void main(String[] args) throws Exception {
         // Read command line
         String query = args[0];

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/SearchIterator.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/SearchIterator.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.example;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.SearchOptions;
 import nl.knaw.dans.lib.dataverse.model.search.DatasetResultItem;
@@ -30,9 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class SearchIterator extends ExampleBase {
-    private static final Logger log = LoggerFactory.getLogger(SearchIterator.class);
-
     public static void main(String[] args) throws Exception {
         // Read command line
         String query = args[0];

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -47,9 +47,9 @@ abstract class AbstractApi {
 
     protected Map<String, List<String>> getQueryParamsFromMetadataKeys(Map<String, String> metadataKeys) {
         return metadataKeys.entrySet().stream()
-                .collect(Collectors.toMap(
-                        e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
-                        e -> Collections.singletonList(e.getValue())
-                ));
+            .collect(Collectors.toMap(
+                e -> MDKEY_PARAM_NAME_PREFIX + e.getKey(),
+                e -> Collections.singletonList(e.getValue())
+            ));
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.Path;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 abstract class AbstractApi {
 
     protected final HttpClientWrapper httpClientWrapper;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +24,7 @@ import java.util.Map;
 
 import static java.util.Collections.singletonList;
 
+@Slf4j
 abstract class AbstractTargetedApi extends AbstractApi {
 
     protected static final String persistendId = ":persistentId/";

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AbstractTargetedApi.java
@@ -36,7 +36,6 @@ abstract class AbstractTargetedApi extends AbstractApi {
 
     protected final Map<String, String> extraHeaders = new HashMap<>();
 
-
     protected AbstractTargetedApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId, Path targetBase) {
         super(httpClientWrapper);
         this.id = id;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 import org.slf4j.Logger;
@@ -31,9 +32,9 @@ import java.util.Map;
  *
  * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#admin" target="_blank">Dataverse documentation</a>
  */
+@Slf4j
 public class AdminApi extends AbstractApi {
 
-    private static final Logger log = LoggerFactory.getLogger(AdminApi.class);
     private final Path targetBase;
 
     protected AdminApi(HttpClientWrapper httpClientWrapper) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
@@ -18,8 +18,6 @@ package nl.knaw.dans.lib.dataverse;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,7 +37,6 @@ public class AdminApi extends AbstractApi {
 
     protected AdminApi(HttpClientWrapper httpClientWrapper) {
         super(httpClientWrapper);
-        log.trace("ENTER");
         this.targetBase = Paths.get("api/admin/");
     }
 
@@ -69,7 +66,7 @@ public class AdminApi extends AbstractApi {
     }
 
     /**
-     * @param key   the settings key
+     * @param key the settings key
      * @return the result
      * @throws IOException        if an I/O exception occurs
      * @throws DataverseException if Dataverse could not handle the request
@@ -79,7 +76,5 @@ public class AdminApi extends AbstractApi {
         Path path = buildPath(targetBase, "settings", key);
         return httpClientWrapper.get(path, DataMessage.class);
     }
-
-
 
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
@@ -40,7 +40,6 @@ public class BasicFileAccessApi extends AbstractTargetedApi {
         super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/access/datafile"));
     }
 
-
     /**
      * @return a HttpResponse object
      * @throws IOException        when I/O problems occur during the interaction with Dataverse

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BasicFileAccessApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.util.Optional;
  *
  * @see <a href="https://guides.dataverse.org/en/latest/api/dataaccess.html#basic-file-access" target="_blank">Dataverse documentation</a>
  */
+@Slf4j
 public class BasicFileAccessApi extends AbstractTargetedApi {
     protected BasicFileAccessApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/access/datafile"));

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/BuiltinUserApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/BuiltinUserApi.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class BuiltinUserApi extends AbstractApi {
 
     protected BuiltinUserApi(HttpClientWrapper httpClientWrapper) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/CompoundFieldBuilder.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundMultiValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.ControlledSingleValueField;
@@ -27,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class CompoundFieldBuilder {
     private final String typeName;
     private final boolean multiple;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
@@ -17,8 +17,6 @@ package nl.knaw.dans.lib.dataverse;
 
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataAccessRequestsApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,34 +27,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class DataAccessRequestsApi extends AbstractTargetedApi {
-
-    private static final Logger log = LoggerFactory.getLogger(DataAccessRequestsApi.class);
     private final Path subPath = subPath("allowAccessRequest/");
     private final Map<String, List<String>> params = params(new HashMap<>());
     private final HashMap<String, String> headers = new HashMap<>();
 
     protected DataAccessRequestsApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/access/"));
-        log.trace("ENTER");
     }
 
     protected DataAccessRequestsApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId, String invocationId) {
         super(httpClientWrapper, id, isPersistentId, invocationId, Paths.get("api/access/"));
-        log.trace("ENTER");
     }
 
-
     public DataverseHttpResponse<DataMessage> enable() throws IOException, DataverseException {
-        log.trace("ENTER");
         return toggle("true");
     }
 
     public DataverseHttpResponse<DataMessage> disable() throws IOException, DataverseException {
-        log.trace("ENTER");
         return toggle("false");
     }
-
 
     private DataverseHttpResponse<DataMessage> toggle(String bool) throws IOException, DataverseException {
         headers.putAll(extraHeaders);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -424,24 +424,6 @@ public class DatasetApi extends AbstractTargetedApi {
         return addFile(file, httpClientWrapper.writeValueAsString(fileMeta));
     }
 
-    /**
-     * @param optDataFile     content of the file
-     * @param optFileMetadata metadata of the file
-     * @return a file list
-     * @throws IOException        when I/O problems occur during the interaction with Dataverse
-     * @throws DataverseException when Dataverse fails to perform the request
-     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#add-a-file-to-a-dataset" target="_blank">Dataverse documentation</a>
-     *
-     * At least one of the parameters should be provided.
-     */
-    public DataverseHttpResponse<FileList> addFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
-        if (!optDataFile.isPresent() && !optFileMetadata.isPresent())
-            throw new IllegalArgumentException("At least one of file data and file metadata must be provided.");
-        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        optDataFile.ifPresent(f -> builder.addPart("file", new FileBody(f, ContentType.APPLICATION_OCTET_STREAM, f.getName())));
-        optFileMetadata.ifPresent(m -> builder.addPart("jsonData", new StringBody(m, ContentType.APPLICATION_JSON)));
-        return httpClientWrapper.post(subPath("add"), builder.build(), params(emptyMap()), new HashMap<>(), FileList.class);
-    }
 
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#report-the-data-file-size-of-a-dataset
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#get-the-size-of-downloading-all-the-files-of-a-dataset-version

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.Lock;
 import nl.knaw.dans.lib.dataverse.model.RoleAssignment;
@@ -25,7 +26,6 @@ import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.Embargo;
 import nl.knaw.dans.lib.dataverse.model.dataset.FieldList;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
-import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
 import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.commons.lang3.StringUtils;
@@ -40,8 +40,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -52,10 +54,9 @@ import static java.util.Collections.singletonMap;
  *
  * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#datasets" target="_blank">Dataverse documentation</a>
  */
+@Slf4j
 public class DatasetApi extends AbstractTargetedApi {
 
-    private static final Logger log = LoggerFactory.getLogger(DatasetApi.class);
-    
     protected DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         this(httpClientWrapper, id, isPersistentId, null);
     }
@@ -167,7 +168,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
      *
      * @param s            JSON document containing the edits to perform
-     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -193,13 +194,12 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow
-     * multiple values. 
-     * Whenever there are metadata field from a block that is protected by a 'key', the corresponding keys must be provided. 
+     * Edits the current draft's metadata, adding the fields that do not exist yet. If `replace` is set to `false`, all specified fields must be either currently empty or allow multiple values.
+     * Whenever there are metadata field from a block that is protected by a 'key', the corresponding keys must be provided.
      *
-     * @param s       JSON document containing the edits to perform
-     * @param replace whether to replace existing values
-     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param s            JSON document containing the edits to perform
+     * @param replace      whether to replace existing values
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -236,7 +236,7 @@ public class DatasetApi extends AbstractTargetedApi {
      *
      * @param fields       list of fields to edit
      * @param replace      whether to replace existing values
-     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -263,7 +263,7 @@ public class DatasetApi extends AbstractTargetedApi {
      * Edits the current draft's metadata, adding the fields that do not exist yet.
      *
      * @param fields       list of fields to edit
-     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.  
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values.
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
@@ -318,7 +318,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * @param s JSON document containing the new metadata
+     * @param s            JSON document containing the new metadata
      * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
      * @return DatasetVersion
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
@@ -332,9 +332,9 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * Note that not all the attributes of the DatasetVersion object are writable. Dataverse may ignore some (e.g., license) or return an error if some are filled in (e.g., files).
-     * However, for a few attributes, such as fileAccessRequest and termsOfAccess, it is necessary to pass the whole version object instead of only
-     * the metadata blocks (as is done in the example of the API documentation).
+     * Note that not all the attributes of the DatasetVersion object are writable. Dataverse may ignore some (e.g., license) or return an error if some are filled in (e.g., files). However, for a few
+     * attributes, such as fileAccessRequest and termsOfAccess, it is necessary to pass the whole version object instead of only the metadata blocks (as is done in the example of the API
+     * documentation).
      *
      * @param version a version object containing the new metadata
      * @return DatasetVersion
@@ -347,7 +347,7 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     /**
-     * @param version a version object containing the new metadata
+     * @param version      a version object containing the new metadata
      * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
      * @return DatasetVersion
      * @throws IOException
@@ -652,5 +652,5 @@ public class DatasetApi extends AbstractTargetedApi {
         if (!lockState.get(locks, lockType))
             throw new RuntimeException(String.format("%s. Number of tries = %d, wait time between tries = %d ms.", errorMessage, maxNumberOfRetries, waitTimeInMilliseconds));
     }
-    
+
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -34,7 +34,6 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -33,8 +33,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,7 +118,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-files-in-a-dataset" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<FileMeta>> getFiles(String version) throws IOException, DataverseException {
-        log.trace("ENTER");
         return getVersionedFromTarget("files", version, List.class, FileMeta.class);
     }
 
@@ -139,7 +136,6 @@ public class DatasetApi extends AbstractTargetedApi {
     }
 
     public DataverseHttpResponse<DataMessage> publish(UpdateType updateType, boolean assureIsIndexed) throws IOException, DataverseException {
-        log.trace("ENTER");
         HashMap<String, List<String>> parameters = new HashMap<>();
         parameters.put("assureIsIndexed", singletonList(String.valueOf(assureIsIndexed)));
         parameters.put("type", singletonList(updateType.toString()));
@@ -189,7 +185,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetVersion> editMetadata(String s, Boolean replace) throws IOException, DataverseException {
-        log.trace("ENTER");
         return editMetadata(s, replace, emptyMap());
     }
 
@@ -206,7 +201,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#edit-dataset-metadata" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetVersion> editMetadata(String s, Boolean replace, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        log.trace("ENTER");
         Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         if (replace)
             /*
@@ -367,7 +361,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#delete-dataset-draft" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> deleteDraft() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.delete(subPath("versions/:draft"), params(emptyMap()), DataMessage.class);
     }
 
@@ -381,7 +374,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-role-assignments-on-a-dataverse-api" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<RoleAssignmentReadOnly>> listRoleAssignments() throws IOException, DataverseException {
-        log.trace("ENTER");
         return getUnversionedFromTarget("assignments", List.class, RoleAssignmentReadOnly.class);
     }
 
@@ -443,7 +435,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * At least one of the parameters should be provided.
      */
     public DataverseHttpResponse<FileList> addFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
-        log.trace("{} {}", optDataFile, optFileMetadata);
         if (!optDataFile.isPresent() && !optFileMetadata.isPresent())
             throw new IllegalArgumentException("At least one of file data and file metadata must be provided.");
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
@@ -504,13 +495,11 @@ public class DatasetApi extends AbstractTargetedApi {
      * Helper methods
      */
     private <D> DataverseHttpResponse<D> getVersionedFromTarget(String endPoint, String version, Class<?>... outputClass) throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(versionedSubPath(endPoint, version), params(emptyMap()), extraHeaders, outputClass);
     }
 
     private <D> DataverseHttpResponse<D> getUnversionedFromTarget(String endPoint, Map<String, List<String>> queryParams, Class<?>... outputClass)
         throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath(endPoint), params(queryParams), extraHeaders, outputClass);
     }
 
@@ -520,7 +509,6 @@ public class DatasetApi extends AbstractTargetedApi {
 
     private <D> DataverseHttpResponse<D> putToTarget(String endPoint, String body, Map<String, List<String>> queryParams, Class<?>... outputClass)
         throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.putJsonString(subPath(endPoint), body, params(queryParams), extraHeaders, outputClass);
     }
 
@@ -532,7 +520,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @see <a href="https://github.com/DANS-KNAW/dans-dataverse-client-lib/blob/master/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/DatasetGetLocks.java">Code example</a>
      */
     public DataverseHttpResponse<List<Lock>> getLocks() throws IOException, DataverseException {
-        log.trace("getting locks from Dataverse");
         return getUnversionedFromTarget("locks", List.class, Lock.class);
     }
 
@@ -547,7 +534,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      */
     public void awaitUnlock(int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException {
-        log.trace(String.format("awaitUnlock: maxNumberOfRetries %d, waitTimeInMilliseconds %d", maxNumberOfRetries, waitTimeInMilliseconds));
         awaitLockState(this::notLocked, "", "Wait for unlock expired", maxNumberOfRetries, waitTimeInMilliseconds);
     }
 
@@ -573,7 +559,6 @@ public class DatasetApi extends AbstractTargetedApi {
      * @throws DataverseException when Dataverse fails to perform the request
      */
     public void awaitLock(String lockType, int maxNumberOfRetries, int waitTimeInMilliseconds) throws IOException, DataverseException {
-        log.trace(String.format("awaitLock: lockType %s, maxNumberOfRetries %d, waitTimeInMilliseconds %d", lockType, maxNumberOfRetries, waitTimeInMilliseconds));
         awaitLockState(this::isLocked, lockType, String.format("Wait for lock of type %s expired", lockType), maxNumberOfRetries, waitTimeInMilliseconds);
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -52,7 +52,6 @@ public class DataverseApi extends AbstractApi {
 
     protected DataverseApi(HttpClientWrapper httpClientWrapper, String alias) {
         super(httpClientWrapper);
-        log.trace("ENTER");
         this.subPath = Paths.get("api/dataverses/").resolve(alias + "/");
     }
 
@@ -64,7 +63,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> create(String dataverse) throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.postJsonString(subPath, dataverse, new HashMap<>(), new HashMap<>(), Dataverse.class);
     }
 
@@ -76,7 +74,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> create(Dataverse dataverse) throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.postModelObjectAsJson(subPath, dataverse, new HashMap<>(), new HashMap<>(), Dataverse.class);
     }
 
@@ -87,7 +84,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#view-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<Dataverse> view() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath, Dataverse.class);
     }
 
@@ -98,7 +94,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#delete-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> delete() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.delete(subPath, DataMessage.class);
     }
 
@@ -109,7 +104,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#show-contents-of-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<DataverseItem>> getContents() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath.resolve("contents"), List.class, DataverseItem.class);
     }
 
@@ -120,7 +114,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#report-the-data-file-size-of-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> getStorageSize() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath.resolve("storagesize"), DataMessage.class);
     }
 
@@ -131,7 +124,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-roles-defined-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<Role>> listRoles() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath.resolve("roles"), List.class, Role.class);
     }
 
@@ -142,7 +134,6 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-facets-configured-for-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> listFacets() throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -151,7 +142,6 @@ public class DataverseApi extends AbstractApi {
      * https://guides.dataverse.org/en/latest/api/native-api.html#set-facets-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> setFacets(List<String> facets) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -159,7 +149,6 @@ public class DataverseApi extends AbstractApi {
     /* https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> createRole(String role) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -168,7 +157,6 @@ public class DataverseApi extends AbstractApi {
      *  https://guides.dataverse.org/en/latest/api/native-api.html#create-a-new-role-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> createRole(Role role) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -183,7 +171,6 @@ public class DataverseApi extends AbstractApi {
      * https://guides.dataverse.org/en/latest/api/native-api.html#assign-default-role-to-user-creating-a-dataset-in-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> assignDefaultRoleOnDataset(String roleName) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -192,7 +179,6 @@ public class DataverseApi extends AbstractApi {
      * https://guides.dataverse.org/en/latest/api/native-api.html#assign-a-new-role-on-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> assignRole(RoleAssignment roleAssignment) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -200,7 +186,6 @@ public class DataverseApi extends AbstractApi {
     /* https://guides.dataverse.org/en/latest/api/native-api.html#delete-role-assignment-from-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> deleteRoleAssignment(int roleAssignmentId) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -212,14 +197,12 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#list-metadata-blocks-defined-on-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<List<MetadataBlockSummary>> listMetadataBlocks() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath.resolve("metadatablocks"), List.class, MetadataBlockSummary.class);
     }
 
     /* https://guides.dataverse.org/en/latest/api/native-api.html#define-metadata-blocks-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> defineMetadataBlocks(List<String> metadataBlocks) throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -228,10 +211,10 @@ public class DataverseApi extends AbstractApi {
      * @return <code>true</code> if this dataverse is a metadata blocks root, <code>false</code> otherwise
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
-     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#determine-if-a-dataverse-collection-inherits-its-metadata-blocks-from-its-parent" target="_blank">Dataverse documentation</a>
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#determine-if-a-dataverse-collection-inherits-its-metadata-blocks-from-its-parent" target="_blank">Dataverse
+     * documentation</a>
      */
     public DataverseHttpResponse<Boolean> isMetadataBlocksRoot() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.get(subPath.resolve("metadatablocks/isRoot"), Boolean.class);
     }
 
@@ -240,10 +223,10 @@ public class DataverseApi extends AbstractApi {
      * @return a data message
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
-     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#configure-a-dataverse-collection-to-inherit-its-metadata-blocks-from-its-parent" target="_blank">Dataverse documentation</a>
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#configure-a-dataverse-collection-to-inherit-its-metadata-blocks-from-its-parent" target="_blank">Dataverse
+     * documentation</a>
      */
     public DataverseHttpResponse<DataMessage> setMetadataBlocksRoot(boolean isRoot) throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.putTextString(subPath.resolve("metadatablocks/isRoot"), Boolean.toString(isRoot), Collections.emptyMap(), Collections.emptyMap(),
             DataMessage.class);
     }
@@ -256,20 +239,18 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset) throws IOException, DataverseException {
-        log.trace("ENTER");
         return createDataset(dataset, Collections.emptyMap());
     }
 
     /**
-     * @param dataset JSON string defining the dataset to create
-     * @param metadataKeys  the HashMap maps the names of the metadata blocks to their 'secret' key values
+     * @param dataset      JSON string defining the dataset to create
+     * @param metadataKeys the HashMap maps the names of the metadata blocks to their 'secret' key values
      * @return a creation result message
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(String dataset, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        log.trace("ENTER");
         Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         return httpClientWrapper.postJsonString(subPath.resolve("datasets"), dataset, queryParams, Collections.emptyMap(), DatasetCreationResult.class);
     }
@@ -282,12 +263,11 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset) throws IOException, DataverseException {
-        log.trace("ENTER");
         return createDataset(httpClientWrapper.writeValueAsString(dataset), Collections.emptyMap());
     }
 
     /**
-     * @param dataset the dataset to create
+     * @param dataset      the dataset to create
      * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
      * @return a creation result message
      * @throws IOException
@@ -295,43 +275,41 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#create-a-dataset-in-a-dataverse-collection">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> createDataset(Dataset dataset, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        log.trace("ENTER");
         return createDataset(httpClientWrapper.writeValueAsString(dataset), metadataKeys);
     }
 
     /**
-     * @param dataset the dataset to import
+     * @param dataset         the dataset to import
      * @param optPersistentId existing persistent identifier (PID)
-     * @param autoPublish immediately publish the dataset
+     * @param autoPublish     immediately publish the dataset
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
-        log.trace("ENTER");
         return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, emptyMap());
     }
 
     /**
-     * @param dataset the dataset to import
+     * @param dataset         the dataset to import
      * @param optPersistentId existing persistent identifier (PID)
-     * @param autoPublish immediately publish the dataset
-     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @param autoPublish     immediately publish the dataset
+     * @param metadataKeys    maps the names of the metadata blocks to their 'secret' key values
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys) throws IOException, DataverseException {
-        log.trace("ENTER");
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys)
+        throws IOException, DataverseException {
         return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, metadataKeys);
     }
 
     /**
-     * @param dataset JSON string defining the dataset to import
+     * @param dataset         JSON string defining the dataset to import
      * @param optPersistentId existing persistent identifier (PID)
-     * @param autoPublish immediately publish the dataset
+     * @param autoPublish     immediately publish the dataset
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
@@ -339,24 +317,21 @@ public class DataverseApi extends AbstractApi {
      */
     public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish)
         throws IOException, DataverseException {
-        log.trace("ENTER");
-
-        return importDataset( dataset, optPersistentId, autoPublish, emptyMap());
+        return importDataset(dataset, optPersistentId, autoPublish, emptyMap());
     }
 
     /**
-     * @param dataset JSON string defining the dataset to import
+     * @param dataset         JSON string defining the dataset to import
      * @param optPersistentId existing persistent identifier (PID)
-     * @param autoPublish immediately publish the dataset
-     * @param metadataKeys maps the names of the metadata blocks to their 'secret' key values
+     * @param autoPublish     immediately publish the dataset
+     * @param metadataKeys    maps the names of the metadata blocks to their 'secret' key values
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys) 
-            throws IOException, DataverseException {
-        log.trace("ENTER");
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys)
+        throws IOException, DataverseException {
         Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         Map<String, List<String>> parameters = new HashMap<>(queryParams);
         optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
@@ -367,7 +342,6 @@ public class DataverseApi extends AbstractApi {
     /* https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-installation-with-a-ddi-file
      */
     public DataverseHttpResponse<DatasetCreationResult> importDatasetFromDdi() throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }
@@ -379,14 +353,12 @@ public class DataverseApi extends AbstractApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#publish-a-dataverse-collection" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<DataMessage> publish() throws IOException, DataverseException {
-        log.trace("ENTER");
         return httpClientWrapper.postJsonString(subPath.resolve(publish), "", new HashMap<>(), new HashMap<>(), DataMessage.class);
     }
 
     /*https://guides.dataverse.org/en/latest/api/native-api.html#retrieve-guestbook-responses-for-a-dataverse-collection
      */
     public DataverseHttpResponse<DataMessage> getGuestBookResponses() throws IOException, DataverseException {
-        log.trace("ENTER");
         // TODO: implement
         throw new UnsupportedOperationException();
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseApi.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -280,20 +279,20 @@ public class DataverseApi extends AbstractApi {
 
     /**
      * @param dataset         the dataset to import
-     * @param optPersistentId existing persistent identifier (PID)
+     * @param persistentId existing persistent identifier (PID)
      * @param autoPublish     immediately publish the dataset
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish) throws IOException, DataverseException {
-        return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, emptyMap());
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, String persistentId, boolean autoPublish) throws IOException, DataverseException {
+        return importDataset(httpClientWrapper.writeValueAsString(dataset), persistentId, autoPublish, emptyMap());
     }
 
     /**
      * @param dataset         the dataset to import
-     * @param optPersistentId existing persistent identifier (PID)
+     * @param persistentId existing persistent identifier (PID)
      * @param autoPublish     immediately publish the dataset
      * @param metadataKeys    maps the names of the metadata blocks to their 'secret' key values
      * @return an import result message
@@ -301,28 +300,28 @@ public class DataverseApi extends AbstractApi {
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys)
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(Dataset dataset, String persistentId, boolean autoPublish, Map<String, String> metadataKeys)
         throws IOException, DataverseException {
-        return importDataset(httpClientWrapper.writeValueAsString(dataset), optPersistentId, autoPublish, metadataKeys);
+        return importDataset(httpClientWrapper.writeValueAsString(dataset), persistentId, autoPublish, metadataKeys);
     }
 
     /**
      * @param dataset         JSON string defining the dataset to import
-     * @param optPersistentId existing persistent identifier (PID)
+     * @param persistentId existing persistent identifier (PID)
      * @param autoPublish     immediately publish the dataset
      * @return an import result message
      * @throws IOException
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish)
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, String persistentId, boolean autoPublish)
         throws IOException, DataverseException {
-        return importDataset(dataset, optPersistentId, autoPublish, emptyMap());
+        return importDataset(dataset, persistentId, autoPublish, emptyMap());
     }
 
     /**
      * @param dataset         JSON string defining the dataset to import
-     * @param optPersistentId existing persistent identifier (PID)
+     * @param persistentId existing persistent identifier (PID)
      * @param autoPublish     immediately publish the dataset
      * @param metadataKeys    maps the names of the metadata blocks to their 'secret' key values
      * @return an import result message
@@ -330,12 +329,14 @@ public class DataverseApi extends AbstractApi {
      * @throws DataverseException
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#import-a-dataset-into-a-dataverse-collection">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, Optional<String> optPersistentId, boolean autoPublish, Map<String, String> metadataKeys)
+    public DataverseHttpResponse<DatasetCreationResult> importDataset(String dataset, String persistentId, boolean autoPublish, Map<String, String> metadataKeys)
         throws IOException, DataverseException {
         Map<String, List<String>> queryParams = getQueryParamsFromMetadataKeys(metadataKeys);
         Map<String, List<String>> parameters = new HashMap<>(queryParams);
-        optPersistentId.ifPresent(pid -> parameters.put("release", singletonList("" + autoPublish)));
-        optPersistentId.ifPresent(pid -> parameters.put("pid", singletonList(pid)));
+        if (persistentId != null) {
+            parameters.put("release", singletonList("" + autoPublish));
+            parameters.put("pid", singletonList(persistentId));
+        }
         return httpClientWrapper.postJsonString(subPath.resolve("datasets/:import"), dataset, parameters, emptyMap(), DatasetCreationResult.class);
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
@@ -23,8 +23,6 @@ import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClient.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.lib.dataverse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
@@ -30,9 +31,8 @@ import java.io.IOException;
 /**
  * Object that lets your code talk to a Dataverse server.
  */
+@Slf4j
 public class DataverseClient {
-    private static final Logger logger = LoggerFactory.getLogger(DataverseClient.class);
-
     private final HttpClientWrapper httpClientWrapper;
     private SearchApi searchApi;
 
@@ -66,9 +66,9 @@ public class DataverseClient {
     }
 
     public void checkConnection() throws IOException, DataverseException {
-        logger.debug("Checking if root dataverse can be reached...");
+        log.debug("Checking if root dataverse can be reached...");
         dataverse("root").view().getData();
-        logger.debug("OK: root dataverse is reachable.");
+        log.debug("OK: root dataverse is reachable.");
     }
 
     public WorkflowsApi workflows() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseItemDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseItemDeserializer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseDatasetItem;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItemType;
 import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseSubverseItem;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
+@Slf4j
 public class DataverseItemDeserializer extends StdDeserializer {
 
     public DataverseItemDeserializer() {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -40,8 +38,6 @@ public class DataverseResponse<D> {
     private final JavaType dataType;
 
     protected DataverseResponse(String bodyText, ObjectMapper mapper, Class<?>... dataClass) {
-        log.trace("ENTER");
-        log.trace(bodyText);
         this.bodyText = bodyText;
         this.mapper = mapper;
         TypeFactory typeFactory = mapper.getTypeFactory();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,9 @@ import java.io.IOException;
  *
  * @param <D> the type of the data of the response message envelope, one of the classes in {@link nl.knaw.dans.lib.dataverse.model}
  */
+
+@Slf4j
 public class DataverseResponse<D> {
-    private static final Logger log = LoggerFactory.getLogger(DataverseResponse.class);
     private final ObjectMapper mapper;
 
     private final String bodyText;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.http.entity.ContentType;
@@ -35,9 +37,8 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 
+@Slf4j
 public class FileApi extends AbstractTargetedApi {
-
-    private static final Logger logger = LoggerFactory.getLogger(DatasetApi.class);
 
     protected FileApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
         super(httpClientWrapper, id, isPersistentId, null, Paths.get("api/v1/files/"));
@@ -64,7 +65,7 @@ public class FileApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<FileList> replaceFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
-        logger.trace("{} {}", optDataFile, optFileMetadata);
+        log.trace("{} {}", optDataFile, optFileMetadata);
         if (!optDataFile.isPresent() && !optFileMetadata.isPresent())
             throw new IllegalArgumentException("At least one of file data and file metadata must be provided.");
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
@@ -15,17 +15,13 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
-import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
-import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.InputStreamBody;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -65,7 +61,6 @@ public class FileApi extends AbstractTargetedApi {
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files" target="_blank">Dataverse documentation</a>
      */
     public DataverseHttpResponse<FileList> replaceFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
-        log.trace("{} {}", optDataFile, optFileMetadata);
         if (!optDataFile.isPresent() && !optFileMetadata.isPresent())
             throw new IllegalArgumentException("At least one of file data and file metadata must be provided.");
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/FileApi.java
@@ -17,19 +17,16 @@ package nl.knaw.dans.lib.dataverse;
 
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.entity.mime.content.InputStreamBody;
+import org.apache.http.entity.mime.content.StringBody;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 
@@ -48,38 +45,55 @@ public class FileApi extends AbstractTargetedApi {
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#uningest-a-file
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#reingest-a-file
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#redetect-file-type
-    // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#getting-file-metadata
     // TODO: https://guides.dataverse.org/en/latest/api/native-api.html#adding-file-metadata
 
+    public DataverseHttpResponse<FileList> replaceFile(Path dataFile, FileMeta fileMeta) throws IOException, DataverseException {
+        return replaceFile(dataFile, httpClientWrapper.writeValueAsString(fileMeta));
+    }
+
     /**
-     * @param optDataFile     the data file
-     * @param optFileMetadata json containing file metadata
+     * @param dataFile the data file
+     * @param fileMeta json containing file metadata
      * @return a file list
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#replacing-files" target="_blank">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<FileList> replaceFileItem(Optional<File> optDataFile, Optional<String> optFileMetadata) throws IOException, DataverseException {
-        if (!optDataFile.isPresent() && !optFileMetadata.isPresent())
+    public DataverseHttpResponse<FileList> replaceFile(Path dataFile, String fileMeta) throws IOException, DataverseException {
+        if (dataFile == null && fileMeta == null)
             throw new IllegalArgumentException("At least one of file data and file metadata must be provided.");
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        optDataFile.ifPresent(f -> builder.addPart("file", new FileBody(f, ContentType.APPLICATION_OCTET_STREAM, f.getName())));
-        optFileMetadata.ifPresent(m -> builder.addPart("jsonData", new InputStreamBody(new ByteArrayInputStream(m.getBytes()), ContentType.APPLICATION_JSON, "jsonData")));
+        if (dataFile != null) {
+            builder.addPart("file", new FileBody(dataFile.toFile(), ContentType.APPLICATION_OCTET_STREAM, dataFile.getFileName().toString()));
+        }
+        if (fileMeta != null) {
+            builder.addPart("jsonData", new StringBody(fileMeta, ContentType.APPLICATION_JSON));
+        }
         return httpClientWrapper.post(subPath("replace"), builder.build(), (emptyMap()), new HashMap<>(), FileList.class);
     }
 
     /**
-     * @param json the file metadata
+     * @param fileMeta the file metadata
      * @return hash map
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata" target="_blank">Dataverse documentation</a>
      */
-    public DataverseHttpResponse<String> updateMetadata(String json) throws IOException, DataverseException {
+    public DataverseHttpResponse<String> updateMetadata(FileMeta fileMeta) throws IOException, DataverseException {
+        return updateMetadata(httpClientWrapper.writeValueAsString(fileMeta));
+    }
+
+    /**
+     * @param fileMeta the file metadata
+     * @return hash map
+     * @throws IOException        when I/O problems occur during the interaction with Dataverse
+     * @throws DataverseException when Dataverse fails to perform the request
+     * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata" target="_blank">Dataverse documentation</a>
+     */
+    public DataverseHttpResponse<String> updateMetadata(String fileMeta) throws IOException, DataverseException {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
-        builder.addBinaryBody("jsonData", json.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON, "jsonData");
+        builder.addPart("jsonData", new StringBody(fileMeta, ContentType.APPLICATION_JSON));
         return httpClientWrapper.post(subPath("metadata"), builder.build(), params(emptyMap()), new HashMap<>(), HashMap.class);
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/GetFileOptions.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/GetFileOptions.java
@@ -15,41 +15,12 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.Data;
+
+@Data
 public class GetFileOptions {
     private String format;
     private boolean noVarHeader;
     private boolean imageThumb;
     private int imageThumbPixels = 64;
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
-    public boolean isNoVarHeader() {
-        return noVarHeader;
-    }
-
-    public void setNoVarHeader(boolean noVarHeader) {
-        this.noVarHeader = noVarHeader;
-    }
-
-    public boolean isImageThumb() {
-        return imageThumb;
-    }
-
-    public void setImageThumb(boolean imageThumb) {
-        this.imageThumb = imageThumb;
-    }
-
-    public int getImageThumbPixels() {
-        return imageThumbPixels;
-    }
-
-    public void setImageThumbPixels(int imageThumbPixels) {
-        this.imageThumbPixels = imageThumbPixels;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/GetFileRange.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/GetFileRange.java
@@ -15,22 +15,17 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.Getter;
+
+@Getter
 public class GetFileRange {
-    private long start;
-    private long end;
+    private final long start;
+    private final long end;
 
     public GetFileRange(long start, long end) {
         if (start >= end)
             throw new IllegalArgumentException("Start must be greater than end");
         this.start = start;
         this.end = end;
-    }
-
-    public long getStart() {
-        return start;
-    }
-
-    public long getEnd() {
-        return end;
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.lib.dataverse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -50,13 +51,11 @@ import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 /**
- * Helper class that wraps an HttpClient, the configuration data and a Jackson object mapper. It implements generic methods for sending HTTP requests to the server and
- * deserializing the responses
+ * Helper class that wraps an HttpClient, the configuration data and a Jackson object mapper. It implements generic methods for sending HTTP requests to the server and deserializing the responses
  * received.
  */
+@Slf4j
 class HttpClientWrapper implements MediaTypes {
-    private static final Logger log = LoggerFactory.getLogger(HttpClientWrapper.class);
-
     private static final String HEADER_X_DATAVERSE_KEY = "X-Dataverse-key";
     private static final String UNBLOCK_KEY = "unblock-key";
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -32,8 +32,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -67,14 +65,12 @@ class HttpClientWrapper implements MediaTypes {
     private boolean sendApiTokenViaBasicAuth = false;
 
     HttpClientWrapper(DataverseClientConfig config, HttpClient httpClient, ObjectMapper mapper) {
-        log.trace("ENTER");
         this.config = config;
         this.httpClient = httpClient;
         this.mapper = mapper;
     }
 
     public HttpClientWrapper sendApiTokenViaBasicAuth() {
-        log.trace("ENTER");
         HttpClientWrapper wrapper = new HttpClientWrapper(getConfig(), httpClient, mapper);
         wrapper.sendApiTokenViaBasicAuth = true;
         return wrapper;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
@@ -19,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.license.CreateLicense;
 import nl.knaw.dans.lib.dataverse.model.license.License;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,7 +37,6 @@ public class LicenseApi extends AbstractApi {
 
     protected LicenseApi(HttpClientWrapper httpClientWrapper) {
         super(httpClientWrapper);
-        log.trace("ENTER");
         this.targetBase = Paths.get("api/licenses/");
     }
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/LicenseApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
 import nl.knaw.dans.lib.dataverse.model.license.CreateLicense;
 import nl.knaw.dans.lib.dataverse.model.license.License;
@@ -32,9 +33,8 @@ import java.util.Map;
  *
  * @see <a href="https://guides.dataverse.org/en/latest/api/native-api.html#id188" target="_blank">Dataverse documentation</a>
  */
+@Slf4j
 public class LicenseApi extends AbstractApi {
-
-    private static final Logger log = LoggerFactory.getLogger(LicenseApi.class);
     private final Path targetBase;
 
     protected LicenseApi(HttpClientWrapper httpClientWrapper) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/MetadataFieldDeserializer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundMultiValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.ControlledMultiValueField;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+@Slf4j
 public class MetadataFieldDeserializer extends StdDeserializer {
 
     public MetadataFieldDeserializer() {
@@ -58,7 +60,8 @@ public class MetadataFieldDeserializer extends StdDeserializer {
 
         if ("primitive".equals(typeClass)) {
             if (multiple) {
-                if (subField) throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
+                if (subField)
+                    throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
                 Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
                 return new PrimitiveMultiValueField(
                     typeName,
@@ -73,7 +76,8 @@ public class MetadataFieldDeserializer extends StdDeserializer {
         }
         else if ("controlledVocabulary".equals(typeClass)) {
             if (multiple) {
-                if (subField) throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
+                if (subField)
+                    throw new IllegalArgumentException("Compound fields cannot contain multi-value subfields");
                 Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
                 return new ControlledMultiValueField(
                     typeName,
@@ -87,14 +91,16 @@ public class MetadataFieldDeserializer extends StdDeserializer {
             }
         }
         else if ("compound".equals(typeClass)) {
-            if (subField) throw new IllegalArgumentException("Compound fields cannot contain compound fields as subfields");
+            if (subField)
+                throw new IllegalArgumentException("Compound fields cannot contain compound fields as subfields");
             if (multiple) {
                 Iterable<JsonNode> jsonNodeIterable = valueNode::elements;
                 return new CompoundMultiValueField(
                     typeName,
                     StreamSupport.stream(jsonNodeIterable.spliterator(), false)
                         .map(this::deserializeCompoundFieldValue).collect(Collectors.toList()));
-            } else {
+            }
+            else {
                 return new CompoundSingleValueField(
                     typeName,
                     deserializeCompoundFieldValue(valueNode));
@@ -112,5 +118,4 @@ public class MetadataFieldDeserializer extends StdDeserializer {
         }
         return subFields;
     }
-
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemDeserializer.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemDeserializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.file.Checksum;
 import nl.knaw.dans.lib.dataverse.model.search.Contact;
 import nl.knaw.dans.lib.dataverse.model.search.DatasetResultItem;
@@ -34,6 +35,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class ResultItemDeserializer extends StdDeserializer {
     private ObjectMapper mapper;
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemIterator.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/ResultItemIterator.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import nl.knaw.dans.lib.dataverse.model.search.SearchResult;
 
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 
+@Slf4j
 class ResultItemIterator implements Iterator<ResultItem> {
     private final SearchApi searchApi;
     private final String query;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
@@ -93,8 +93,7 @@ public class SearchApi extends AbstractApi {
     }
 
     /**
-     * Returns an iterator to all the results for the specified query and default options. The caller is responsible for calling the {@link ResultItem}s to the appropriate
-     * subclass.
+     * Returns an iterator to all the results for the specified query and default options. The caller is responsible for calling the {@link ResultItem}s to the appropriate subclass.
      *
      * @param query the query to execute
      * @return an iterator over the results

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import nl.knaw.dans.lib.dataverse.model.search.SearchResult;
 
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class SearchApi extends AbstractApi {
     private final Path subPath = Paths.get("api", "search");
 

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchOptions.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchOptions.java
@@ -15,16 +15,18 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.search.SearchItemType;
 
 import java.util.List;
 
 /**
- * Options for searching, such as further narrowing down the result, what to include in the result items and which part of the result to return, and in what order. See [Dataverse API Guide] for
- * details.
+ * Options for searching, such as further narrowing down the result, what to include in the result items and which part of the result to return, and in what order.
  *
- * [Dataverse API Guide]: https://guides.dataverse.org/en/latest/api/search.html#parameters
+ * @see <a href="https://guides.dataverse.org/en/latest/api/search.html#parameters" target="_blank">Dataverse documentation</a>
  */
+@Data
 public class SearchOptions {
     public enum Order {
         asc,
@@ -57,83 +59,4 @@ public class SearchOptions {
         return copy;
     }
 
-    public List<SearchItemType> getTypes() {
-        return types;
-    }
-
-    public void setTypes(List<SearchItemType> types) {
-        this.types = types;
-    }
-
-    public List<String> getFilterQueries() {
-        return filterQueries;
-    }
-
-    public void setFilterQueries(List<String> filterQueries) {
-        this.filterQueries = filterQueries;
-    }
-
-    public List<String> getSubTrees() {
-        return subTrees;
-    }
-
-    public void setSubTrees(List<String> subTrees) {
-        this.subTrees = subTrees;
-    }
-
-    public String getSortField() {
-        return sortField;
-    }
-
-    public void setSortField(String sortField) {
-        this.sortField = sortField;
-    }
-
-    public Order getOrder() {
-        return order;
-    }
-
-    public void setOrder(Order order) {
-        this.order = order;
-    }
-
-    public int getPerPage() {
-        return perPage;
-    }
-
-    public void setPerPage(int perPage) {
-        this.perPage = perPage;
-    }
-
-    public int getStart() {
-        return start;
-    }
-
-    public void setStart(int start) {
-        this.start = start;
-    }
-
-    public boolean isShowRelevance() {
-        return showRelevance;
-    }
-
-    public void setShowRelevance(boolean showRelevance) {
-        this.showRelevance = showRelevance;
-    }
-
-    public boolean isShowFacets() {
-        return showFacets;
-    }
-
-    public void setShowFacets(boolean showFacets) {
-        this.showFacets = showFacets;
-    }
-
-    public boolean isShowEntityIds() {
-        return showEntityIds;
-    }
-
-    public void setShowEntityIds(boolean showEntityIds) {
-        this.showEntityIds = showEntityIds;
-    }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchOptions.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SearchOptions.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.lib.dataverse;
 
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.search.SearchItemType;
 
 import java.util.List;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
@@ -17,8 +17,6 @@ package nl.knaw.dans.lib.dataverse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/SwordApi.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,27 +24,23 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+@Slf4j
 public class SwordApi extends AbstractApi {
-
-    private static final Logger log = LoggerFactory.getLogger(SwordApi.class);
 
     protected SwordApi(HttpClientWrapper httpClientWrapper) {
         super(httpClientWrapper.sendApiTokenViaBasicAuth());
-        log.trace("ENTER");
     }
 
     /**
      * Deletes a file from the current draft of the dataset.
      *
-     * @param databaseId the database ID of the file to delete.
-     *                   To look up use @{link DatasetApi#listFiles}.
+     * @param databaseId the database ID of the file to delete. To look up use @{link DatasetApi#listFiles}.
      * @return a generic http response
      * @throws IOException        when I/O problems occur during the interaction with Dataverse
      * @throws DataverseException when Dataverse fails to perform the request
      * @see <a href="https://guides.dataverse.org/en/latest/api/sword.html#delete-a-file-by-database-id" target="_blank">Dataverse documentation</a>
      */
     public HttpResponse deleteFile(int databaseId) throws IOException, DataverseException {
-        log.trace("ENTER");
         Path path = Paths.get("/dvn/api/data-deposit/v1.1/swordv2/edit-media/file/" + databaseId);
         return httpClientWrapper.delete(path);
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/TokenApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/TokenApi.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class TokenApi extends AbstractApi {
     protected TokenApi(HttpClientWrapper httpClientWrapper) {
         super(httpClientWrapper);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/WorkflowsApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/WorkflowsApi.java
@@ -15,12 +15,14 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.workflow.ResumeMessage;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+@Slf4j
 public class WorkflowsApi extends AbstractApi {
 
     private static final Path subPath = Paths.get("api/workflows/");

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/UpdateType.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/UpdateType.java
@@ -15,4 +15,4 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
-public enum UpdateType { major, minor}
+public enum UpdateType {major, minor}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseItem.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataverse/DataverseItem.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 public abstract class DataverseItem {
     private DataverseItemType type;
     private int id;
+
     public DataverseItem(DataverseItemType type) {
         this.type = type;
     }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/Checksum.java
@@ -24,6 +24,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Checksum {
 
-  private String type;
-  private String Value;
+    private String type;
+    private String Value;
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
@@ -22,23 +22,23 @@ import lombok.Data;
 @Data
 @JsonIgnoreProperties({ "md5" }) // The optional "md5" property is redundant and only there for backward compatibility. 
 public class DataFile {
-  private int   id;
-  private String persistentId;
-  private String pidURL;
-  private String filename;
-  private String contentType;
-  private long filesize;
-  private String description;
-  private Embargo embargo;
-  private String storageIdentifier;
-  private String originalFileFormat;
-  private String originalFormatLabel;
-  private Long originalFileSize;
-  private String originalFileName;
-  @JsonProperty("UNF")
-  private String unf;
-  private int rootDataFileId;
-  private Checksum checksum;
-  private String creationDate;
-  private int previousDataFileId;
+    private int id;
+    private String persistentId;
+    private String pidURL;
+    private String filename;
+    private String contentType;
+    private long filesize;
+    private String description;
+    private Embargo embargo;
+    private String storageIdentifier;
+    private String originalFileFormat;
+    private String originalFormatLabel;
+    private Long originalFileSize;
+    private String originalFileName;
+    @JsonProperty("UNF")
+    private String unf;
+    private int rootDataFileId;
+    private Checksum checksum;
+    private String creationDate;
+    private int previousDataFileId;
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/FileMeta.java
@@ -20,7 +20,6 @@ import nl.knaw.dans.lib.dataverse.model.file.prestaged.Checksum;
 import nl.knaw.dans.lib.dataverse.model.file.prestaged.PrestagedFile;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 @Data

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/license/CreateLicense.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/license/CreateLicense.java
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.lib.dataverse.model.license;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/package-info.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/package-info.java
@@ -16,9 +16,8 @@
 /**
  * <h1>Main package for the DANS Dataverse Client Library</h1>
  * <p>
- * The starting point to work with the libary is the class {@link nl.knaw.dans.lib.dataverse.DataverseClient}. It is instantiated with a
- * {@link nl.knaw.dans.lib.dataverse.DataverseClientConfig} to point it to a particular Dataverse server and provide it with the necessary credentials,
- * e.g. an API token.
+ * The starting point to work with the libary is the class {@link nl.knaw.dans.lib.dataverse.DataverseClient}. It is instantiated with a {@link nl.knaw.dans.lib.dataverse.DataverseClientConfig} to
+ * point it to a particular Dataverse server and provide it with the necessary credentials, e.g. an API token.
  * </p>
  */
 package nl.knaw.dans.lib.dataverse;

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/AddFileTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/AddFileTest.java
@@ -18,7 +18,6 @@ package nl.knaw.dans.lib.dataverse;
 import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
 import nl.knaw.dans.lib.dataverse.model.ModelFixture;
 import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
-import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/MapperFixture.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/MapperFixture.java
@@ -18,8 +18,8 @@ package nl.knaw.dans.lib.dataverse;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
+import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import org.junit.jupiter.api.BeforeEach;
 

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelopeTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/DataverseEnvelopeTest.java
@@ -15,8 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DataverseEnvelopeTest extends ModelFixture {
     private static final Class<?> classUnderTest = DataverseEnvelope.class;

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueFieldTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/dataset/ControlledSingleValueFieldTest.java
@@ -15,8 +15,9 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ControlledSingleValueFieldTest extends ModelDatasetMapperFixture {
     private static final Class<?> classUnderTest = ControlledSingleValueField.class;

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/dataset/LicenseTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/model/dataset/LicenseTest.java
@@ -15,10 +15,11 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LicenseTest extends ModelDatasetMapperFixture {
     private static final Class<License> classUnderTest = License.class;


### PR DESCRIPTION
NO JIRA.

# Description of changes
* Use Lombok annotation to add logger to all classes except pure data classes that do not contain any logic.
* Removed trace logging statements. They only clutter the logging output. When it is necessary to trace a call through the library, use the debugger instead.
* Removed `Optional` arguments, as it seems to be widely [regarded as a bad practice](https://www.baeldung.com/java-optional#misuages). This is a backwards incompatible change, so some client modules will need to be modified.
* Consistently prefer `java.nio.file.Path` over `java.io.File`.
* Removed `addFileItem` which was already implemented as `addFile`.
* Fixed some of the multi-part requests that were unnecessarily converting Strings to bytes.
* Code formatting
* Organize imports

# Notify

@DANS-KNAW/dataversedans
