### PR TITLE
Added properties to DatasetVersion and License to support Dataverse v5.14

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
@@ -56,4 +56,7 @@ public class DatasetVersion {
     private Map<String, MetadataBlock> metadataBlocks;
     private List<FileMeta> files;
     private String citation;
+    private String publicationDate;
+    private String citationDate;
+    private String alternativePersistentId;
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/License.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/License.java
@@ -27,4 +27,5 @@ import java.net.URI;
 public class License {
     private String name;
     private URI uri;
+    private URI iconUri;
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/file/DataFile.java
@@ -19,6 +19,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @JsonIgnoreProperties({ "md5" }) // The optional "md5" property is redundant and only there for backward compatibility. 
 public class DataFile {
@@ -41,4 +44,5 @@ public class DataFile {
     private Checksum checksum;
     private String creationDate;
     private int previousDataFileId;
+    private List<String> categories = new ArrayList<>();
 }

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
@@ -41,7 +41,7 @@ public class DataverseResponseTest extends MapperFixture {
     }
 
     @Test
-    public void DatasetVersionWithMD5InFilesResponseCanBeDeserialized() throws Exception {
+    public void datasetVersionWithMD5InFilesResponseCanBeDeserialized() throws Exception {
         DataverseResponse<DatasetVersion> r =
                 new DataverseResponse<>(FileUtils.readFileToString(getTestJsonFileFor(classUnderTest, 
                         "DatasetVersionWithMD5InFiles"), StandardCharsets.UTF_8),
@@ -55,7 +55,7 @@ public class DataverseResponseTest extends MapperFixture {
     }
 
     @Test
-    public void DatasetVersionWithAddedPropsUpTov5_14ResponseCanBeDeserialized() throws Exception {
+    public void datasetVersionWithAddedPropsUpTov5_14ResponseCanBeDeserialized() throws Exception {
         DataverseResponse<DatasetVersion> r =
             new DataverseResponse<>(FileUtils.readFileToString(getTestJsonFileFor(classUnderTest,
                 "DatasetVersionWithAddedPropsUpTov5_14"), StandardCharsets.UTF_8),
@@ -71,13 +71,5 @@ public class DataverseResponseTest extends MapperFixture {
         Assertions.assertEquals("hdl:10695/test-12345", r.getData().getAlternativePersistentId());
         Assertions.assertEquals("Documentation", r.getData().getFiles().get(4).getDataFile().getCategories().get(0));
     }
-
-//    @Test
-//    public void nestedTypeParametersCanBeDeserialized() throws Exception {
-//        DataverseResponse<List<DatasetVersion>> r = new DataverseResponse<>(FileUtils.readFileToString(new File("src/test/resources/dataverse-response/test2.json"), StandardCharsets.UTF_8),
-//            mapper, List.class, DatasetVersion.class);
-//        // TODO: REPLACE WITH ASSERTION
-//        System.out.println(r.getData().get(0).getCreateTime());
-//    }
 
 }

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 public class DataverseResponseTest extends MapperFixture {
@@ -52,6 +53,22 @@ public class DataverseResponseTest extends MapperFixture {
         Assertions.assertEquals(3, r.getData().getVersionNumber());
         Assertions.assertEquals(5, r.getData().getFiles().size());
     }
+//DatasetVersionWithAddedPropsUpTov5.14
+@Test
+public void DatasetVersionWithAddedPropsUpTov5_14ResponseCanBeDeserialized() throws Exception {
+    DataverseResponse<DatasetVersion> r =
+        new DataverseResponse<>(FileUtils.readFileToString(getTestJsonFileFor(classUnderTest,
+            "DatasetVersionWithAddedPropsUpTov5_14"), StandardCharsets.UTF_8),
+            mapper, DatasetVersion.class);
+    // check some standard properties
+    Assertions.assertEquals(2, r.getData().getDatasetId());
+    Assertions.assertEquals(3, r.getData().getVersionNumber());
+    Assertions.assertEquals(5, r.getData().getFiles().size());
+    // check some added properties
+    Assertions.assertEquals(new URI("https://licensebuttons.net/l/zero/1.0/88x31.png"), r.getData().getLicense().getIconUri());
+}
+
+
 
 //    @Test
 //    public void nestedTypeParametersCanBeDeserialized() throws Exception {

--- a/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
+++ b/lib/src/test/java/nl/knaw/dans/lib/dataverse/DataverseResponseTest.java
@@ -53,22 +53,24 @@ public class DataverseResponseTest extends MapperFixture {
         Assertions.assertEquals(3, r.getData().getVersionNumber());
         Assertions.assertEquals(5, r.getData().getFiles().size());
     }
-//DatasetVersionWithAddedPropsUpTov5.14
-@Test
-public void DatasetVersionWithAddedPropsUpTov5_14ResponseCanBeDeserialized() throws Exception {
-    DataverseResponse<DatasetVersion> r =
-        new DataverseResponse<>(FileUtils.readFileToString(getTestJsonFileFor(classUnderTest,
-            "DatasetVersionWithAddedPropsUpTov5_14"), StandardCharsets.UTF_8),
-            mapper, DatasetVersion.class);
-    // check some standard properties
-    Assertions.assertEquals(2, r.getData().getDatasetId());
-    Assertions.assertEquals(3, r.getData().getVersionNumber());
-    Assertions.assertEquals(5, r.getData().getFiles().size());
-    // check some added properties
-    Assertions.assertEquals(new URI("https://licensebuttons.net/l/zero/1.0/88x31.png"), r.getData().getLicense().getIconUri());
-}
 
-
+    @Test
+    public void DatasetVersionWithAddedPropsUpTov5_14ResponseCanBeDeserialized() throws Exception {
+        DataverseResponse<DatasetVersion> r =
+            new DataverseResponse<>(FileUtils.readFileToString(getTestJsonFileFor(classUnderTest,
+                "DatasetVersionWithAddedPropsUpTov5_14"), StandardCharsets.UTF_8),
+                mapper, DatasetVersion.class);
+        // check some standard properties
+        Assertions.assertEquals(2, r.getData().getDatasetId());
+        Assertions.assertEquals(3, r.getData().getVersionNumber());
+        Assertions.assertEquals(5, r.getData().getFiles().size());
+        // check added properties
+        Assertions.assertEquals(new URI("https://licensebuttons.net/l/zero/1.0/88x31.png"), r.getData().getLicense().getIconUri());
+        Assertions.assertEquals("2023-01-10", r.getData().getPublicationDate());
+        Assertions.assertEquals("2023-01-10", r.getData().getCitationDate());
+        Assertions.assertEquals("hdl:10695/test-12345", r.getData().getAlternativePersistentId());
+        Assertions.assertEquals("Documentation", r.getData().getFiles().get(4).getDataFile().getCategories().get(0));
+    }
 
 //    @Test
 //    public void nestedTypeParametersCanBeDeserialized() throws Exception {

--- a/lib/src/test/resources/DataverseResponse-DatasetVersionWithAddedPropsUpTov5_14.json
+++ b/lib/src/test/resources/DataverseResponse-DatasetVersionWithAddedPropsUpTov5_14.json
@@ -1,0 +1,270 @@
+{
+  "status": "OK",
+  "data": {
+    "id": 5,
+    "datasetId": 2,
+    "datasetPersistentId": "doi:10.80227/test-FUB0OA",
+    "storageIdentifier": "file://10.80227/test-FUB0OA",
+    "versionNumber": 3,
+    "versionMinorNumber": 1,
+    "versionState": "DRAFT",
+    "lastUpdateTime": "2023-01-10T13:02:58Z",
+    "createTime": "2023-01-10T13:02:58Z",
+    "publicationDate":"2023-01-10",
+    "citationDate":"2023-01-10",
+    "license": {
+      "name": "CC0 1.0",
+      "uri": "http://creativecommons.org/publicdomain/zero/1.0",
+      "iconUri": "https://licensebuttons.net/l/zero/1.0/88x31.png"
+    },
+    "fileAccessRequest": false,
+    "metadataBlocks": {
+      "citation": {
+        "displayName": "Citation Metadata",
+        "name": "citation",
+        "fields": [
+          {
+            "typeName": "title",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "test1"
+          },
+          {
+            "typeName": "subtitle",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "Subje"
+          },
+          {
+            "typeName": "author",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "authorName": {
+                  "typeName": "authorName",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Admin, Dataverse"
+                },
+                "authorAffiliation": {
+                  "typeName": "authorAffiliation",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Dataverse.org"
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "datasetContact",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "datasetContactName": {
+                  "typeName": "datasetContactName",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Admin, Dataverse"
+                },
+                "datasetContactAffiliation": {
+                  "typeName": "datasetContactAffiliation",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Dataverse.org"
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "dsDescription",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "dsDescriptionValue": {
+                  "typeName": "dsDescriptionValue",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "test1"
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "subject",
+            "multiple": true,
+            "typeClass": "controlledVocabulary",
+            "value": [
+              "Earth and Environmental Sciences"
+            ]
+          },
+          {
+            "typeName": "depositor",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "Admin, Dataverse"
+          },
+          {
+            "typeName": "dateOfDeposit",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "2022-04-14"
+          }
+        ]
+      },
+      "dansDataVaultMetadata": {
+        "displayName": "Data Vault Metadata",
+        "name": "dansDataVaultMetadata",
+        "fields": [
+          {
+            "typeName": "dansDataversePid",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "doi:10.80227/test-FUB0OA"
+          },
+          {
+            "typeName": "dansDataversePidVersion",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "3.0"
+          },
+          {
+            "typeName": "dansBagId",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "urn:uuid:5ef14d2c-10f5-4b5a-a55b-01618f2d4009"
+          },
+          {
+            "typeName": "dansNbn",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "urn:nbn:nl:ui:13-0fcd7b84-3fd4-49f0-918a-b60eec8d9e6c"
+          }
+        ]
+      }
+    },
+    "files": [
+      {
+        "label": "1kB-1.bin",
+        "restricted": false,
+        "version": 1,
+        "datasetVersionId": 5,
+        "dataFile": {
+          "id": 7,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "1kB-1.bin",
+          "contentType": "application/macbinary",
+          "filesize": 1024,
+          "storageIdentifier": "file://18040f4fd7d-56fcd0ce7ae4",
+          "rootDataFileId": -1,
+          "md5": "ca492e46698218627813b8f037986e94",
+          "checksum": {
+            "type": "MD5",
+            "value": "ca492e46698218627813b8f037986e94"
+          },
+          "creationDate": "2022-04-19"
+        }
+      },
+      {
+        "label": "1MB-1.bin",
+        "restricted": false,
+        "version": 1,
+        "datasetVersionId": 5,
+        "dataFile": {
+          "id": 8,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "1MB-1.bin",
+          "contentType": "application/macbinary",
+          "filesize": 1048576,
+          "storageIdentifier": "file://18040f50bcc-fe457992a1ed",
+          "rootDataFileId": -1,
+          "md5": "6f438741cf7e0c7917a92156efdbaea1",
+          "checksum": {
+            "type": "MD5",
+            "value": "6f438741cf7e0c7917a92156efdbaea1"
+          },
+          "creationDate": "2022-04-19"
+        }
+      },
+      {
+        "label": "test1.txt",
+        "restricted": false,
+        "directoryLabel": "duplicate-test",
+        "version": 1,
+        "datasetVersionId": 5,
+        "dataFile": {
+          "id": 11,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "test1.txt",
+          "contentType": "text/plain",
+          "filesize": 6,
+          "storageIdentifier": "file://18040f67f85-a009ac4ae60a",
+          "rootDataFileId": -1,
+          "md5": "3e7705498e8be60520841409ebc69bc1",
+          "checksum": {
+            "type": "MD5",
+            "value": "3e7705498e8be60520841409ebc69bc1"
+          },
+          "creationDate": "2022-04-19"
+        }
+      },
+      {
+        "label": "test2.txt",
+        "restricted": false,
+        "directoryLabel": "duplicate-test/dir1",
+        "version": 1,
+        "datasetVersionId": 5,
+        "dataFile": {
+          "id": 10,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "test2.txt",
+          "contentType": "text/plain",
+          "filesize": 6,
+          "storageIdentifier": "file://18040f67f99-454dfa8a5bac",
+          "rootDataFileId": -1,
+          "md5": "126a8a51b9d1bbd07fddc65819a542c3",
+          "checksum": {
+            "type": "MD5",
+            "value": "126a8a51b9d1bbd07fddc65819a542c3"
+          },
+          "creationDate": "2022-04-19"
+        }
+      },
+      {
+        "label": "test2.txt",
+        "restricted": false,
+        "directoryLabel": "duplicate-test/dir2",
+        "version": 1,
+        "datasetVersionId": 5,
+        "categories": [
+          "Documentation"
+        ],
+        "dataFile": {
+          "id": 9,
+          "persistentId": "",
+          "pidURL": "",
+          "filename": "test2.txt",
+          "contentType": "text/plain",
+          "filesize": 6,
+          "categories": [
+            "Documentation"
+          ],
+          "storageIdentifier": "file://18040f67f8e-2e4fb2e431ff",
+          "rootDataFileId": -1,
+          "md5": "126a8a51b9d1bbd07fddc65819a542c3",
+          "checksum": {
+            "type": "MD5",
+            "value": "126a8a51b9d1bbd07fddc65819a542c3"
+          },
+          "creationDate": "2022-04-19"
+        }
+      }
+    ]
+  }
+}

--- a/lib/src/test/resources/DataverseResponse-DatasetVersionWithAddedPropsUpTov5_14.json
+++ b/lib/src/test/resources/DataverseResponse-DatasetVersionWithAddedPropsUpTov5_14.json
@@ -12,6 +12,7 @@
     "createTime": "2023-01-10T13:02:58Z",
     "publicationDate":"2023-01-10",
     "citationDate":"2023-01-10",
+    "alternativePersistentId": "hdl:10695/test-12345",
     "license": {
       "name": "CC0 1.0",
       "uri": "http://creativecommons.org/publicdomain/zero/1.0",


### PR DESCRIPTION
Fixes DD-1417 Update For Dataverse v5.14 

# Description of changes
Added properties to the DatasetVersion and sub -objects corresponding o new JSON properties exported by the API of v5.14. 
In DatasetVersion
- publicationDate
- citationDate
- alternativePersistentId

In License:
- iconUri

In DataFile
- categories



# How to test
Use a server (vagrant box) with Dataverse v5.14 deployed. 
Then have `dd-vault-metadata` build using this new library, deploy that on the server. 
Create and publish a dataset, this should succeed, where it failed with the old library. 

# Related PRs
New PR on `dd-vault-metadata`

(Add links)

* https://github.com/DANS-KNAW/dd-vault-metadata/pull/10

# Notify

@DANS-KNAW/dataversedans
