### PR TITLE
Retry dataset publication on awaiting indexing failure

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -29,6 +29,7 @@ import nl.knaw.dans.lib.dataverse.model.dataset.FileList;
 import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
@@ -168,19 +169,19 @@ public class DatasetApi extends AbstractTargetedApi {
             try {
                 return publishWithoutRetries(updateType, true);
             } catch (DataverseException e) {
-                if (e.getStatus() != 409) {
+                if (e.getStatus() != HttpStatus.SC_CONFLICT) {
                     log.error("Not an awaiting indexing status {}, rethrowing exception", e.getStatus());
                     throw e;
                 }
-                log.info("Attempt to publish dataset failed because Dataset is awaiting indexing");
+                log.debug("Attempt to publish dataset failed because Dataset is awaiting indexing");
                 retry_count++;
-                log.info("Retry count: {}", retry_count);
+                log.debug("Retry count: {}", retry_count);
                 if(retry_count == awaitIndexingMaxNumberOfRetries) {
                     log.error("Max retries ({}) reached, stop trying to publish dataset", awaitIndexingMaxNumberOfRetries);
                     throw e;
                 }
                 try {
-                    log.info("Sleeping for {} milliseconds before trying again", awaitIndexingMillisecondsBetweenRetries);
+                    log.debug("Sleeping for {} milliseconds before trying again", awaitIndexingMillisecondsBetweenRetries);
                     Thread.sleep(awaitIndexingMillisecondsBetweenRetries);
                 }
                 catch (InterruptedException ex) {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClientConfig.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseClientConfig.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib.dataverse;
 
+import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType;
+
 import java.net.URI;
 
 public class DataverseClientConfig {
@@ -22,22 +24,37 @@ public class DataverseClientConfig {
     private final String apiToken;
     private final int awaitLockStateMaxNumberOfRetries;
     private final int awaitLockStateMillisecondsBetweenRetries;
+    private final int awaitIndexingMaxNumberOfRetries;
+    private final int awaitIndexingMillisecondsBetweenRetries;
+
     private final String unblockKey;
+
+    public static final int DEFAULT_AWAIT_LOCK_STATE_MAX_NUMBER_OF_RETRIES = 30;
+    public static final int DEFAULT_AWAIT_LOCK_STATE_MILLISECONDS_BETWEEN_RETRIES = 500;
+    public static final int DEFAULT_AWAIT_INDEXING_MAX_NUMBER_OF_RETRIES = 15;
+    public static final int DEFAULT_AWAIT_INDEXING_MILLISECONDS_BETWEEN_RETRIES = 1000;
 
     /**
      * Configuration settings for the {@link DataverseClient}.
      *
      * @param baseUrl                                  the base URL of the Dataverse server to communicate with
      * @param apiToken                                 the API token used for authorization
-     * @param awaitLockStateMaxNumberOfRetries         the maximum number of tries for {@link DatasetApi#awaitLock(String)} API (default 30)
-     * @param awaitLockStateMillisecondsBetweenRetries the number or milliseconds to wait between tries for {@link DatasetApi#awaitLock(String)} API (default 500)
+     * @param awaitLockStateMaxNumberOfRetries         the maximum number of tries for {@link DatasetApi#awaitLock(String)} API (default {@value #DEFAULT_AWAIT_LOCK_STATE_MAX_NUMBER_OF_RETRIES})
+     * @param awaitLockStateMillisecondsBetweenRetries the number of milliseconds to wait between tries for {@link DatasetApi#awaitLock(String)} API (default {@value #DEFAULT_AWAIT_LOCK_STATE_MILLISECONDS_BETWEEN_RETRIES})
+     * @param awaitIndexingMaxNumberOfRetries          the maximum number of tries for {@link DatasetApi#publish(UpdateType, boolean)} API (default {@value #DEFAULT_AWAIT_INDEXING_MAX_NUMBER_OF_RETRIES})
+     * @param awaitIndexingMillisecondsBetweenRetries  the number of milliseconds to wait between tries for {@link DatasetApi#publish(UpdateType, boolean)} API (default {@value #DEFAULT_AWAIT_INDEXING_MILLISECONDS_BETWEEN_RETRIES})
      * @param unblockKey                               a key required for admin tasks when not running on localhost
      */
-    public DataverseClientConfig(URI baseUrl, String apiToken, int awaitLockStateMaxNumberOfRetries, int awaitLockStateMillisecondsBetweenRetries, String unblockKey) {
+    public DataverseClientConfig(URI baseUrl, String apiToken,
+            int awaitLockStateMaxNumberOfRetries, int awaitLockStateMillisecondsBetweenRetries,
+            int awaitIndexingMaxNumberOfRetries, int awaitIndexingMillisecondsBetweenRetries,
+            String unblockKey) {
         this.baseUrl = baseUrl;
         this.apiToken = apiToken;
         this.awaitLockStateMaxNumberOfRetries = awaitLockStateMaxNumberOfRetries;
         this.awaitLockStateMillisecondsBetweenRetries = awaitLockStateMillisecondsBetweenRetries;
+        this.awaitIndexingMaxNumberOfRetries = awaitIndexingMaxNumberOfRetries;
+        this.awaitIndexingMillisecondsBetweenRetries = awaitIndexingMillisecondsBetweenRetries;
         this.unblockKey = unblockKey;
     }
 
@@ -49,7 +66,10 @@ public class DataverseClientConfig {
      * @param unblockKey a key required for admin tasks when not running on localhost
      */
     public DataverseClientConfig(URI baseUrl, String apiToken, String unblockKey) {
-        this(baseUrl, apiToken, 30, 500, unblockKey);
+        this(baseUrl, apiToken,
+            DEFAULT_AWAIT_LOCK_STATE_MAX_NUMBER_OF_RETRIES, DEFAULT_AWAIT_LOCK_STATE_MILLISECONDS_BETWEEN_RETRIES,
+            DEFAULT_AWAIT_INDEXING_MAX_NUMBER_OF_RETRIES, DEFAULT_AWAIT_INDEXING_MILLISECONDS_BETWEEN_RETRIES,
+            unblockKey);
     }
 
     /**
@@ -59,7 +79,10 @@ public class DataverseClientConfig {
      * @param apiToken the API token used for authorization
      */
     public DataverseClientConfig(URI baseUrl, String apiToken) {
-        this(baseUrl, apiToken, 30, 500, null);
+        this(baseUrl, apiToken,
+            DEFAULT_AWAIT_LOCK_STATE_MAX_NUMBER_OF_RETRIES, DEFAULT_AWAIT_LOCK_STATE_MILLISECONDS_BETWEEN_RETRIES,
+            DEFAULT_AWAIT_INDEXING_MAX_NUMBER_OF_RETRIES, DEFAULT_AWAIT_INDEXING_MILLISECONDS_BETWEEN_RETRIES,
+            null);
     }
 
     /**
@@ -85,6 +108,14 @@ public class DataverseClientConfig {
 
     int getAwaitLockStateMillisecondsBetweenRetries() {
         return awaitLockStateMillisecondsBetweenRetries;
+    }
+
+    int getAwaitIndexingMaxNumberOfRetries() {
+        return awaitIndexingMaxNumberOfRetries;
+    }
+
+    int getAwaitIndexingMillisecondsBetweenRetries() {
+        return awaitIndexingMillisecondsBetweenRetries;
     }
 
     public String getUnblockKey() {


### PR DESCRIPTION
Fixes DD-1433

# Description of changes
When a dataset publish is requested with the option to assure indexing, the result might be a failure 409 status code. 
This PR will then try to publish again, with a delay and a maximum number of retries. 
If another failure happens or the max retries is reached without success, the publish fails. 
 
# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
