### PR TITLE
DD-1469: Added missing custom dataset terms fields to the DatasetVersion class

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/DatasetVersion.java
@@ -42,6 +42,13 @@ public class DatasetVersion {
     private String productionDate;
     private Boolean fileAccessRequest;
     private String termsOfUse;
+    private String confidentialityDeclaration;
+    private String specialPermissions;
+    private String restrictions;
+    private String citationRequirements;
+    private String depositorRequirements;
+    private String conditions;
+    private String disclaimer;
     private String termsOfAccess;
     private String dataAccessPlace;
     private String originalArchive;


### PR DESCRIPTION
Fixes DD-1469

# Description of changes
Added missing custom dataset terms fields to the DatasetVersion class


# How to test
Building this produces a snapshot, you have to use that one in 'dd-vault-metadata'. 
So edit that pom file; `<version>0.25.0-SNAPSHOT</version>`. and build dd-vault-metadata with that. 
Copy the rpm to the dd-dtap shared folder and install that rpm on the vagrant box. 
Then change the terms of a dataset, make sure you can select 'custom terms' by setting the `AllowCustomTermsOfUse`. 
`curl -X PUT -d 'true' 'http://localhost:8080/api/admin/settings/:AllowCustomTermsOfUse'`. 
Then publish the new version of that dataset, this should succeed when the new rpm is installed. 

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
