### PR TITLE
DD-1575 validate dataset files

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminValidateDatasetFiles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminValidateDatasetFiles.java
@@ -16,12 +16,9 @@
 package nl.knaw.dans.lib.dataverse.example;
 
 import lombok.extern.slf4j.Slf4j;
-import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.DataverseResponseWithoutEnvelope;
 import nl.knaw.dans.lib.dataverse.ExampleBase;
 import nl.knaw.dans.lib.dataverse.model.DatasetFileValidationResultList;
-
-import java.util.Map;
 
 @Slf4j
 public class AdminValidateDatasetFiles extends ExampleBase {
@@ -35,7 +32,7 @@ public class AdminValidateDatasetFiles extends ExampleBase {
         } catch (NumberFormatException e) {
             r = client.admin().validateDatasetFiles(id);
         }
-        log.info(r.getAsJson().toPrettyString());
+        log.info(r.getBodyAsJson().toPrettyString());
         for (var result : r.getBodyAsObject().getDataFiles()) {
             log.info("File: {}", result.getDatafileId());
             log.info("  Storage Identifier: {}", result.getStorageIdentifier());

--- a/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminValidateDatasetFiles.java
+++ b/examples/src/main/java/nl/knaw/dans/lib/dataverse/example/AdminValidateDatasetFiles.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.example;
+
+import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
+import nl.knaw.dans.lib.dataverse.DataverseResponseWithoutEnvelope;
+import nl.knaw.dans.lib.dataverse.ExampleBase;
+import nl.knaw.dans.lib.dataverse.model.DatasetFileValidationResultList;
+
+import java.util.Map;
+
+@Slf4j
+public class AdminValidateDatasetFiles extends ExampleBase {
+
+    public static void main(String[] args) throws Exception {
+        var id = args[0];
+        DataverseResponseWithoutEnvelope<DatasetFileValidationResultList> r;
+        // If id is parseable as a number, it is assumed to be a dataset id.
+        try {
+            r = client.admin().validateDatasetFiles(Integer.parseInt(id));
+        } catch (NumberFormatException e) {
+            r = client.admin().validateDatasetFiles(id);
+        }
+        log.info(r.getAsJson().toPrettyString());
+        for (var result : r.getBodyAsObject().getDataFiles()) {
+            log.info("File: {}", result.getDatafileId());
+            log.info("  Storage Identifier: {}", result.getStorageIdentifier());
+            log.info("  Status: {}", result.getStatus());
+        }
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/AdminApi.java
@@ -18,12 +18,14 @@ package nl.knaw.dans.lib.dataverse;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.model.DataMessage;
+import nl.knaw.dans.lib.dataverse.model.DatasetFileValidationResultList;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -77,6 +79,26 @@ public class AdminApi extends AbstractApi {
     public DataverseHttpResponse<DataMessage> getDatabaseSetting(String key) throws IOException, DataverseException {
         Path path = buildPath(targetBase, "settings", key);
         return httpClientWrapper.get(path, DataMessage.class);
+    }
+
+    public DataverseHttpResponseWithoutEnvelope<DatasetFileValidationResultList> validateDatasetFiles(int dbId) throws IOException, DataverseException {
+        return validateDatasetFiles(Integer.toString(dbId), false);
+    }
+
+    public DataverseHttpResponseWithoutEnvelope<DatasetFileValidationResultList> validateDatasetFiles(String pid) throws IOException, DataverseException {
+        return validateDatasetFiles(pid, true);
+    }
+
+    public DataverseHttpResponseWithoutEnvelope<DatasetFileValidationResultList> validateDatasetFiles(String id, boolean isPersistentId) throws IOException, DataverseException {
+        Path path = buildPath(targetBase, "validate/dataset/files");
+        var queryParameters = new HashMap<String, List<String>>();
+        if (isPersistentId) {
+            path = path.resolve(":persistentId");
+            queryParameters.put("persistentId", List.of(id));
+        } else {
+            path = path.resolve(id);
+        }
+        return httpClientWrapper.getWithoutEnvelope(path, queryParameters, new HashMap<>(), DatasetFileValidationResultList.class);
     }
 
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DatasetApi.java
@@ -58,11 +58,6 @@ import static java.util.Collections.singletonMap;
  */
 @Slf4j
 public class DatasetApi extends AbstractTargetedApi {
-
-    DatasetApi(HttpClientWrapper httpClientWrapper, String id, boolean isPersistentId) {
-        this(httpClientWrapper, id, isPersistentId, null);
-    }
-
     @Override
     public String toString() {
         return format("DatasetApi(id=''{0}, isPersistentId={1})", id, isPersistentId);

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseHttpResponseWithoutEnvelope.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseHttpResponseWithoutEnvelope.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 public class DataverseHttpResponseWithoutEnvelope<D> extends DataverseResponseWithoutEnvelope<D> {
     private final HttpResponse httpResponse;
 
-    @SneakyThrows
     DataverseHttpResponseWithoutEnvelope(DispatchResult dispatchResult, ObjectMapper customMapper, Class<?>... dataClass) throws IOException {
         super(dispatchResult.getBody(), customMapper, dataClass);
         this.httpResponse = dispatchResult.getResponse();

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseHttpResponseWithoutEnvelope.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseHttpResponseWithoutEnvelope.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.HttpResponse;
+
+import java.io.IOException;
+
+public class DataverseHttpResponseWithoutEnvelope<D> extends DataverseResponseWithoutEnvelope<D> {
+    private final HttpResponse httpResponse;
+
+    @SneakyThrows
+    DataverseHttpResponseWithoutEnvelope(DispatchResult dispatchResult, ObjectMapper customMapper, Class<?>... dataClass) throws IOException {
+        super(dispatchResult.getBody(), customMapper, dataClass);
+        this.httpResponse = dispatchResult.getResponse();
+    }
+
+    public HttpResponse getHttpResponse() {
+        return httpResponse;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponse.java
@@ -23,7 +23,7 @@ import nl.knaw.dans.lib.dataverse.model.DataverseEnvelope;
 import java.io.IOException;
 
 /**
- * Response from Dataverse.
+ * Response from Dataverse, wrapped in a {@link nl.knaw.dans.lib.dataverse.model.DataverseEnvelope}.
  *
  * @param <D> the type of the data of the response message envelope, one of the classes in {@link nl.knaw.dans.lib.dataverse.model}
  */
@@ -31,10 +31,10 @@ import java.io.IOException;
 @Slf4j
 public class DataverseResponse<D> extends DataverseResponseWithoutEnvelope<DataverseEnvelope<D>> {
     protected DataverseResponse(String bodyText, ObjectMapper mapper, Class<?>... dataClass) {
-        super(bodyText, mapper, envelope(dataClass));
+        super(bodyText, mapper, wrapInEnvelope(dataClass));
     }
 
-    private static Class<?>[] envelope(Class<?>... otherClasses) {
+    private static Class<?>[] wrapInEnvelope(Class<?>... otherClasses) {
         Class<?>[] combined = new Class<?>[otherClasses.length + 1];
         combined[0] = DataverseEnvelope.class;
         System.arraycopy(otherClasses, 0, combined, 1, otherClasses.length);
@@ -62,13 +62,13 @@ public class DataverseResponse<D> extends DataverseResponseWithoutEnvelope<Datav
      * @throws com.fasterxml.jackson.core.JsonParseException if body cannot be processed properly as JSON
      */
     public JsonNode getEnvelopeAsJson() throws IOException {
-        return super.getAsJson();
+        return super.getBodyAsJson();
     }
 
     /**
      * @return the body as a String
      */
     public String getEnvelopeAsString() {
-        return super.getAsString();
+        return super.getBodyAsString();
     }
 }

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponseWithoutEnvelope.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/DataverseResponseWithoutEnvelope.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * Response from Dataverse.
+ *
+ * @param <D> the type of the data of the response message envelope, one of the classes in {@link nl.knaw.dans.lib.dataverse.model}
+ */
+
+@Slf4j
+public class DataverseResponseWithoutEnvelope<D> {
+    private final ObjectMapper mapper;
+
+    private final String bodyText;
+    private final JavaType dataType;
+
+    protected DataverseResponseWithoutEnvelope(String bodyText, ObjectMapper mapper, Class<?>... dataClass) {
+        this.bodyText = bodyText;
+        this.mapper = mapper;
+        TypeFactory typeFactory = mapper.getTypeFactory();
+        switch (dataClass.length) {
+            case 0:
+                throw new IllegalArgumentException("No parameter type given");
+            case 1:
+                this.dataType = typeFactory.constructType(dataClass[0]);
+                break;
+            case 2:
+                this.dataType = typeFactory.constructParametricType(dataClass[0], dataClass[1]);
+                break;
+            default:
+                throw new IllegalArgumentException("Currently no more than one nested parameter type supported");
+        }
+    }
+
+
+    /**
+     * @return the body as bean of type D
+     * @throws com.fasterxml.jackson.core.JsonParseException if body cannot be processed properly as JSON
+     */
+    public D getBodyAsObject() throws IOException {
+        return mapper.readValue(bodyText, dataType);
+    }
+
+    /**
+     * @return the body as a JsonNode
+     * @throws com.fasterxml.jackson.core.JsonParseException if body cannot be processed properly as JSON
+     */
+    public JsonNode getAsJson() throws IOException {
+        return mapper.readTree(bodyText);
+    }
+
+    /**
+     * @return the body as a String
+     */
+    public String getAsString() {
+        return bodyText;
+    }
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/HttpClientWrapper.java
@@ -173,6 +173,13 @@ class HttpClientWrapper implements MediaTypes {
         return wrap(dispatch(get), outputClass);
     }
 
+    public <D> DataverseHttpResponseWithoutEnvelope<D> getWithoutEnvelope(Path subPath, Map<String, List<String>> parameters, Map<String, String> headers, Class<?>... outputClass)
+            throws IOException, DataverseException {
+        var get = new HttpGet(buildURi(subPath, parameters));
+        headers.forEach(get::setHeader);
+        return wrapWithoutEnvelope(dispatch(get), outputClass);
+    }
+
     public <T> T get(Path subPath, Map<String, List<String>> parameters, Map<String, String> headers, HttpClientResponseHandler<T> handler) throws IOException, DataverseException {
         var get = new HttpGet(buildURi(subPath, parameters));
         headers.forEach(get::setHeader);
@@ -217,6 +224,10 @@ class HttpClientWrapper implements MediaTypes {
 
     private <D> DataverseHttpResponse<D> wrap(DispatchResult result, Class<?>... dataClass) throws IOException {
         return new DataverseHttpResponse<>(result, mapper, dataClass);
+    }
+
+    private <D> DataverseHttpResponseWithoutEnvelope<D> wrapWithoutEnvelope(DispatchResult result, Class<?>... dataClass) throws IOException {
+        return new DataverseHttpResponseWithoutEnvelope<>(result, mapper, dataClass);
     }
 
     private DispatchResult dispatch(HttpRequest request) throws IOException, DataverseException {

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DatasetFileValidationResult.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DatasetFileValidationResult.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model;
+
+import lombok.Data;
+
+@Data
+public class DatasetFileValidationResult {
+    private int datafileId;
+    private String storageIdentifier;
+    private String status;
+}

--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DatasetFileValidationResultList.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/DatasetFileValidationResultList.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.dataverse.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class DatasetFileValidationResultList {
+    private List<DatasetFileValidationResult> dataFiles;
+}


### PR DESCRIPTION
Fixes DD-1575

# Description of changes
Preparation for DD-1575. Added the function `validateDatasetFiles` to the `admin` endpoint group, which invokes https://guides.dataverse.org/en/latest/api/native-api.html#physical-files-validation-in-a-dataset. 

Since the JSON returned by this API endpoint does not use the normal envelope (with the "status" and "data" fields) I had to refactor `DataverseResponse` and related classes to handle unwrapped responses. To this end I introduced `DataverseResponseWithoutEnvelope`. 

# How to test
* Use the example programs.
* Use the new version of the library in the microservices that use it.

Both have been done by me, although not comprehensively.


# Notify

@DANS-KNAW/core-systems
