### PR TITLE
DD-2372 Leave Embargo.reason out if not set

### DIFF
--- a/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
+++ b/lib/src/main/java/nl/knaw/dans/lib/dataverse/model/dataset/Embargo.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse.model.dataset;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Embargo {
     private String dateAvailable;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String reason;
     private int[] fileIds;
 }


### PR DESCRIPTION
Fixes DD-2372

# Description of changes
Dataverse will throw an exception if, on setting an embargo, the `reason` field is explicitly set to `null`.  We therefore leave it out if `null`.


# Notify

@DANS-KNAW/core-systems
